### PR TITLE
Installer + CI: single-exe installer via Inno Setup, built in GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,174 @@
+name: Build installer
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to stamp into the installer filename (default: 0.1.0-<short-sha>)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write  # for release uploads on tag pushes
+
+env:
+  CARGO_TERM_COLOR: always
+  # Pin to the latest published 24H2 WDK at time of writing. Bump
+  # whenever the build switches to a newer header.
+  WDK_INSTALLER_URL: "https://go.microsoft.com/fwlink/?linkid=2272234"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # -----------------------------------------------------------------
+      # Compute a version string.  Tag push (v1.2.3) → 1.2.3.  Anything
+      # else → 0.1.0-<short-sha> or the workflow_dispatch input.
+      # -----------------------------------------------------------------
+      - name: Compute version
+        id: ver
+        shell: pwsh
+        run: |
+          $v = ""
+          if ("${{ github.event_name }}" -eq "workflow_dispatch" -and "${{ inputs.version }}") {
+              $v = "${{ inputs.version }}"
+          } elseif ("${{ github.ref }}" -like "refs/tags/v*") {
+              $v = "${{ github.ref }}" -replace "refs/tags/v", ""
+          } else {
+              $sha = "${{ github.sha }}".Substring(0, 7)
+              $v = "0.1.0-$sha"
+          }
+          Write-Host "Version: $v"
+          "version=$v" >> $env:GITHUB_OUTPUT
+
+      # -----------------------------------------------------------------
+      # Toolchains
+      # -----------------------------------------------------------------
+      - name: Set up Rust (stable, x86_64-pc-windows-msvc)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            service/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('service/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      - name: Install WDK
+        shell: pwsh
+        run: |
+          $installer = Join-Path $env:RUNNER_TEMP "wdksetup.exe"
+          Write-Host "Downloading WDK from $env:WDK_INSTALLER_URL"
+          Invoke-WebRequest -Uri $env:WDK_INSTALLER_URL -OutFile $installer -UseBasicParsing
+          Write-Host "Installing WDK (silent, ~5 min)..."
+          $p = Start-Process -FilePath $installer -ArgumentList "/features", "+", "/q", "/norestart" -Wait -PassThru
+          Write-Host "WDK installer exit code: $($p.ExitCode)"
+          # 0 = success, 3010 = success-with-reboot-required (OK in CI)
+          if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010) {
+              throw "WDK installer failed with exit $($p.ExitCode)"
+          }
+
+      # Visual Studio's developer command prompt needs to be activated
+      # to expose msbuild on PATH for the driver toolset.
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      # -----------------------------------------------------------------
+      # Build
+      # -----------------------------------------------------------------
+      - name: Build driver (Release|x64)
+        shell: pwsh
+        run: |
+          msbuild driver\StreamToSpeaker.sln `
+            /p:Configuration=Release `
+            /p:Platform=x64 `
+            /p:SignMode=Off `
+            /nologo `
+            /verbosity:minimal
+          if (-not (Test-Path "driver\x64\Release\StreamToSpeaker\StreamToSpeaker.sys")) {
+              Get-ChildItem -Recurse driver\x64\Release\ | Select-Object FullName
+              throw "Driver .sys not produced where expected"
+          }
+
+      - name: Build service (cargo --release)
+        shell: pwsh
+        working-directory: service
+        run: cargo build --release
+
+      - name: Stage artifacts for installer
+        shell: pwsh
+        run: |
+          $staging = "installer\staging"
+          if (Test-Path $staging) { Remove-Item -Recurse -Force $staging }
+          New-Item -ItemType Directory -Path $staging | Out-Null
+          Copy-Item "service\target\release\stream-to-speaker.exe" "$staging\stream-to-speaker.exe"
+          $wanted = "StreamToSpeaker.sys", "StreamToSpeaker.inf", "StreamToSpeaker.cat"
+          foreach ($name in $wanted) {
+              $found = Get-ChildItem -Path "driver\x64\Release" -Recurse -Filter $name -ErrorAction SilentlyContinue `
+                       | Select-Object -First 1
+              if ($found) {
+                  Copy-Item $found.FullName "$staging\$name" -Force
+                  Write-Host "Staged $($found.FullName)"
+              } elseif ($name -eq "StreamToSpeaker.cat") {
+                  Write-Host "$name not produced (unsigned build)"
+              } else {
+                  throw "Required driver artifact $name not found"
+              }
+          }
+
+      - name: Build installer (Inno Setup)
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) { throw "ISCC not at $iscc" }
+          & $iscc "/DAppVersion=${{ steps.ver.outputs.version }}" "installer\StreamToSpeaker.iss"
+          if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit $LASTEXITCODE" }
+
+      # -----------------------------------------------------------------
+      # Publish
+      # -----------------------------------------------------------------
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: StreamToSpeakerSetup-${{ steps.ver.outputs.version }}
+          path: installer/out/StreamToSpeakerSetup-*.exe
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload raw driver + service binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ steps.ver.outputs.version }}
+          path: |
+            driver/x64/Release/StreamToSpeaker/StreamToSpeaker.sys
+            driver/x64/Release/StreamToSpeaker/StreamToSpeaker.inf
+            driver/x64/Release/StreamToSpeaker/StreamToSpeaker.cat
+            service/target/release/stream-to-speaker.exe
+          if-no-files-found: warn
+
+      - name: Attach to GitHub Release (tag push only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: installer/out/StreamToSpeakerSetup-*.exe
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ driver/*.suo
 driver/*.user
 driver/.vs/
 
+# Installer output
+installer/out/
+installer/staging/
+installer/*.iss.log
+
 # IDE
 .idea/
 .vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2026 Stream To Speaker contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---
+
+This project incorporates code derived from:
+
+- Microsoft sysvad sample driver (MIT License)
+  https://github.com/microsoft/Windows-driver-samples
+
+- swyh-rs (MIT License)
+  https://github.com/dheijl/swyh-rs

--- a/README.md
+++ b/README.md
@@ -210,7 +210,51 @@ Pass `--web` to enable. Then `http://<host>:5901/` serves a tiny status page wit
 
 - **Driver**: VS 2022 Build Tools (or EWDK) + Windows Driver Kit (WDK) 10.0.22621+. See `driver/README.md`.
 - **Service**: Rust 1.74+ stable. `cargo build --release` from `service/`. Produces `target/release/stream-to-speaker.exe`.
+- **Installer** (optional): [Inno Setup 6](https://jrsoftware.org/isdl.php) — `choco install innosetup` works too.
 - **Test signing** (development): Secure Boot off, `bcdedit /set testsigning on`, reboot. HVCI / Memory Integrity must be off in Windows Security → Device Security → Core Isolation.
+
+## Building the installer
+
+A single-file installer (`StreamToSpeakerSetup-<version>.exe`) ties together the driver, the service binary, the endpoint-rename script, and Start Menu / autostart entries.
+
+```powershell
+# Builds driver + service + installer in one shot. Output:
+# installer\out\StreamToSpeakerSetup-<version>.exe
+.\installer\build-installer.ps1
+
+# Or skip individual steps while iterating:
+.\installer\build-installer.ps1 -SkipDriver        # only re-package
+.\installer\build-installer.ps1 -SkipDriver -SkipService
+.\installer\build-installer.ps1 -Version 0.1.0-rc.1
+```
+
+Per-step source: driver via msbuild, service via cargo, installer via Inno Setup's `ISCC.exe`.
+
+### What the installer does on a target machine
+
+1. Copies `stream-to-speaker.exe` to `Program Files\Stream To Speaker`.
+2. Drops `StreamToSpeaker.sys`/`.inf`/`.cat` into a `driver\` subdirectory.
+3. Runs `pnputil /add-driver /install` — stages the driver and (on Win10 1809+) creates the Root-enumerated device.
+4. Runs `scripts\Rename-Endpoint.ps1` to overwrite the cached "Internal AUX Jack" string in the registry.
+5. Optionally adds a Start Menu shortcut, a desktop shortcut, and an autostart entry (per-user `Run` key).
+6. Offers to launch the app on exit.
+
+Uninstall (via Control Panel → Apps): kills any running `stream-to-speaker.exe`, removes the driver via `Uninstall-Driver.ps1` (looks up the `oemNN.inf` assigned name in the driver store), deletes the install directory.
+
+### Caveat: driver signing
+
+The unsigned driver produced by `cargo`/`msbuild` won't load on a normal Windows machine. For development, the target needs test-signing mode + Secure Boot off + HVCI off (see Build prerequisites above). For a shippable installer that doesn't need test-signing, the `.sys` has to be signed with an EV code-signing certificate and WHQL-attested through the Microsoft Hardware Dev Center portal — out of scope for this repo right now.
+
+## Continuous integration
+
+The `.github/workflows/build.yml` workflow builds driver + service + installer on every push, PR, and tag, on `windows-latest` runners. Artifacts:
+
+- **`StreamToSpeakerSetup-<version>.exe`** — the installer
+- **`binaries-<version>`** — raw `.sys`/`.inf`/`.cat` + `stream-to-speaker.exe`
+
+On a tag push (`v1.2.3`), the installer is also attached to a GitHub Release with auto-generated notes.
+
+The workflow installs the WDK from Microsoft's redistributable URL (~5 min cold cache) and Inno Setup via chocolatey. Cargo is cached by `Cargo.lock` hash. Full cold build takes ~15-20 minutes; warm cache cuts it to ~5.
 
 ## Layout
 

--- a/installer/StreamToSpeaker.iss
+++ b/installer/StreamToSpeaker.iss
@@ -1,0 +1,162 @@
+; -----------------------------------------------------------------------------
+; Stream To Speaker — Inno Setup script.
+;
+; Produces a single-file installer that:
+;   1. Copies stream-to-speaker.exe to Program Files\Stream To Speaker
+;   2. Drops the driver package (.sys + .inf [+ .cat]) into a subdir
+;   3. Runs `pnputil /add-driver` to stage + install the driver (Win10 1809+
+;      auto-installs root-enumerated devices when the INF matches)
+;   4. Runs the bundled PowerShell script to overwrite the cached
+;      "Internal AUX Jack — Stream To Speaker" name in the registry
+;   5. Creates a Start Menu shortcut and (opt-in) an auto-start entry
+;   6. On uninstall: kills any running stream-to-speaker.exe, removes
+;      the driver via pnputil (looked up by Original Name), deletes files
+;
+; Build with: ISCC.exe installer\StreamToSpeaker.iss
+; Output:     installer\out\StreamToSpeakerSetup-<ver>.exe
+;
+; Requirements before running the installer on a target machine:
+;   - Windows 10 1809+ (the driver INF targets that)
+;   - Test signing on, Secure Boot off, HVCI off — unless the driver
+;     binary is WHQL-signed (not yet)
+; -----------------------------------------------------------------------------
+
+#define MyAppName        "Stream To Speaker"
+#define MyAppShortName   "StreamToSpeaker"
+#define MyAppExeName     "stream-to-speaker.exe"
+; Override on the command line: ISCC /DAppVersion=0.1.0
+#ifndef AppVersion
+  #define AppVersion     "0.1.0"
+#endif
+#define MyAppPublisher   "Stream To Speaker"
+#define MyAppURL         "https://github.com/Mihonarium/StreamToSpeaker"
+
+[Setup]
+; AppId is a fixed GUID so future installer versions detect us as an upgrade
+; instead of installing side-by-side. Generated once; do not change.
+AppId={{8A6C7F92-3E1B-4A2B-9F1C-77F1B6B2A6E0}
+AppName={#MyAppName}
+AppVersion={#AppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+VersionInfoVersion={#AppVersion}
+DefaultDirName={autopf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+LicenseFile={#SourcePath}\..\LICENSE
+OutputDir={#SourcePath}\out
+OutputBaseFilename={#MyAppShortName}Setup-{#AppVersion}
+Compression=lzma2
+SolidCompression=yes
+PrivilegesRequired=admin
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+MinVersion=10.0.17763
+WizardStyle=modern
+UninstallDisplayIcon={app}\{#MyAppExeName}
+SetupLogging=yes
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "startmenuicon"; Description: "Create a Start Menu shortcut";  GroupDescription: "Shortcuts:"
+Name: "desktopicon";   Description: "Create a desktop shortcut";       GroupDescription: "Shortcuts:"; Flags: unchecked
+Name: "autostart";     Description: "Start {#MyAppName} when I sign in"; GroupDescription: "Startup:";   Flags: unchecked
+
+[Files]
+; All artifacts come from installer\staging\ — populated by
+; installer\build-installer.ps1 (or the CI workflow's staging step)
+; before ISCC runs. This decouples the .iss from WDK / Cargo output
+; path conventions that vary by toolchain version.
+
+; --- Service binary ---
+Source: "{#SourcePath}\staging\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+
+; --- Driver package ---
+Source: "{#SourcePath}\staging\StreamToSpeaker.sys"; DestDir: "{app}\driver"; Flags: ignoreversion
+Source: "{#SourcePath}\staging\StreamToSpeaker.inf"; DestDir: "{app}\driver"; Flags: ignoreversion
+; The .cat file only exists when the driver has been signed.
+; skipifsourcedoesntexist means the installer still builds against an
+; unsigned development build (pnputil install will fail on the user
+; machine, but that's a separate concern).
+Source: "{#SourcePath}\staging\StreamToSpeaker.cat"; DestDir: "{app}\driver"; Flags: ignoreversion skipifsourcedoesntexist
+
+; --- Scripts ---
+Source: "{#SourcePath}\..\scripts\Rename-Endpoint.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
+Source: "{#SourcePath}\Uninstall-Driver.ps1";           DestDir: "{app}\scripts"; Flags: ignoreversion
+
+; --- Docs ---
+Source: "{#SourcePath}\..\README.md"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourcePath}\..\LICENSE";   DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\{#MyAppName}";         Filename: "{app}\{#MyAppExeName}"; Tasks: startmenuicon
+Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Registry]
+; Opt-in autostart — runs the GUI when the user signs in. The default
+; mode (no flags) opens the window + adds the system tray; users who
+; ticked this task probably want minimised-to-tray UX. We add /no-tray
+; OFF (i.e. default tray-on) and rely on the window being closable to
+; the tray. A future iteration could add a --minimized flag.
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
+    ValueType: string; ValueName: "{#MyAppName}"; \
+    ValueData: """{app}\{#MyAppExeName}"""; \
+    Tasks: autostart; Flags: uninsdeletevalue
+
+[Run]
+; 1) Install the driver package. pnputil stages it into DriverStore and,
+;    when the INF describes a Root-enumerated device on Win10 1809+,
+;    creates the device automatically. Output captured via /subst-args.
+Filename: "{sys}\pnputil.exe"; \
+    Parameters: "/add-driver ""{app}\driver\StreamToSpeaker.inf"" /install"; \
+    StatusMsg: "Installing audio driver..."; \
+    Flags: runhidden waituntilterminated
+
+; 2) Overwrite the cached endpoint friendly name (the Windows registry
+;    keeps the auto-generated "Internal AUX Jack ..." string across
+;    reinstalls; this script writes the same slot Sound Settings'
+;    Rename button writes to).
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+    Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\Rename-Endpoint.ps1"""; \
+    StatusMsg: "Naming the audio endpoint..."; \
+    Flags: runhidden waituntilterminated
+
+; 3) Offer to launch the app at the end of install.
+Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; \
+    Flags: nowait postinstall skipifsilent
+
+[UninstallRun]
+; Kill any running instance before yanking the driver out from under it.
+Filename: "{sys}\taskkill.exe"; Parameters: "/F /IM {#MyAppExeName}"; \
+    Flags: runhidden; RunOnceId: "KillService"
+
+; Remove the driver package. pnputil /delete-driver expects the OEM-
+; assigned name (oemNN.inf) which we don't know up front, so we shell
+; into a PowerShell that enumerates the driver store, finds the entry
+; whose OriginalName matches StreamToSpeaker.inf, and uninstalls it.
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+    Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\Uninstall-Driver.ps1"""; \
+    Flags: runhidden waituntilterminated; RunOnceId: "RemoveDriver"
+
+[Code]
+function InitializeSetup(): Boolean;
+var
+  Major, Minor, Build: Cardinal;
+  Version: TWindowsVersion;
+begin
+  Result := True;
+  GetWindowsVersionEx(Version);
+  Major := Version.Major;
+  Minor := Version.Minor;
+  Build := Version.Build;
+  if (Major < 10) or ((Major = 10) and (Build < 17763)) then begin
+    MsgBox('Stream To Speaker requires Windows 10 build 17763 (1809) or later. ' + #13#10 +
+           'Detected: ' + IntToStr(Major) + '.' + IntToStr(Minor) + '.' + IntToStr(Build),
+           mbError, MB_OK);
+    Result := False;
+  end;
+end;

--- a/installer/Uninstall-Driver.ps1
+++ b/installer/Uninstall-Driver.ps1
@@ -1,0 +1,36 @@
+# Uninstalls the Stream To Speaker driver package from the Windows
+# driver store. Called from the Inno Setup [UninstallRun] section.
+#
+# pnputil /delete-driver expects the OEM-assigned name (oemNN.inf) that
+# the driver store handed out on /add-driver. We don't know that name
+# up front, so this script enumerates the driver store, finds the entry
+# whose "Original Name" matches StreamToSpeaker.inf, and uninstalls it.
+
+$ErrorActionPreference = "SilentlyContinue"
+
+$enumOutput = & pnputil /enum-drivers 2>&1 | Out-String
+if (-not $enumOutput) {
+    Write-Output "pnputil enum-drivers returned no output; driver may already be gone."
+    exit 0
+}
+
+# pnputil output groups each driver in a stanza with blank-line
+# separators. We split on blank lines and look for ones containing
+# our INF.
+$stanzas = $enumOutput -split "`r?`n`r?`n"
+$removed = 0
+foreach ($stanza in $stanzas) {
+    if ($stanza -match "Original Name:\s*StreamToSpeaker\.inf") {
+        if ($stanza -match "Published Name:\s*(oem\d+\.inf)") {
+            $oemName = $matches[1]
+            Write-Output "Removing driver package $oemName ..."
+            & pnputil /delete-driver $oemName /uninstall /force | Out-Null
+            $removed++
+        }
+    }
+}
+
+if ($removed -eq 0) {
+    Write-Output "No matching driver package found in the driver store."
+}
+exit 0

--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -1,0 +1,156 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Build the Stream To Speaker installer end-to-end.
+
+.DESCRIPTION
+    Drives:
+      1. msbuild on the driver solution (Release|x64)
+      2. cargo build --release on the service crate
+      3. ISCC.exe on the Inno Setup script
+
+    Each step skipped with -SkipDriver / -SkipService / -SkipInstaller
+    if you want to iterate on one part.
+
+.PARAMETER Configuration
+    Driver build configuration. Default: Release.
+
+.PARAMETER Version
+    Version string baked into the installer filename and AppVersion.
+
+.EXAMPLE
+    .\installer\build-installer.ps1
+
+.EXAMPLE
+    .\installer\build-installer.ps1 -Version 0.1.0-rc.1 -SkipDriver
+#>
+[CmdletBinding()]
+param(
+    [string]$Configuration = "Release",
+    [string]$Version = "0.1.0",
+    [switch]$SkipDriver,
+    [switch]$SkipService,
+    [switch]$SkipInstaller
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+Set-Location $repoRoot
+
+function Write-Step($msg) {
+    Write-Host ""
+    Write-Host "==> $msg" -ForegroundColor Cyan
+}
+
+# ---------------------------------------------------------------------------
+# 1. Driver
+# ---------------------------------------------------------------------------
+if (-not $SkipDriver) {
+    Write-Step "Building driver ($Configuration|x64)"
+    $msbuild = Get-Command msbuild.exe -ErrorAction SilentlyContinue
+    if (-not $msbuild) {
+        $candidates = @(
+            "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
+            "${env:ProgramFiles}\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe",
+            "${env:ProgramFiles}\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe",
+            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe"
+        )
+        $msbuild = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $msbuild) {
+            throw "msbuild.exe not found on PATH or in standard VS2022 locations. Install VS 2022 Build Tools + WDK."
+        }
+        $msbuildExe = $msbuild
+    } else {
+        $msbuildExe = $msbuild.Source
+    }
+    & $msbuildExe (Join-Path $repoRoot "driver\StreamToSpeaker.sln") `
+        "/p:Configuration=$Configuration" `
+        "/p:Platform=x64" `
+        "/nologo" `
+        "/verbosity:minimal"
+    if ($LASTEXITCODE -ne 0) { throw "Driver build failed (exit $LASTEXITCODE)" }
+} else {
+    Write-Step "Skipping driver build (-SkipDriver)"
+}
+
+# ---------------------------------------------------------------------------
+# 2. Service
+# ---------------------------------------------------------------------------
+if (-not $SkipService) {
+    Write-Step "Building service (cargo --release)"
+    Push-Location (Join-Path $repoRoot "service")
+    try {
+        & cargo build --release
+        if ($LASTEXITCODE -ne 0) { throw "Service build failed (exit $LASTEXITCODE)" }
+    } finally {
+        Pop-Location
+    }
+} else {
+    Write-Step "Skipping service build (-SkipService)"
+}
+
+# ---------------------------------------------------------------------------
+# 3. Stage artifacts into installer\staging\ so the .iss has a stable
+#    path to source from (decouples it from WDK / Cargo output dirs).
+# ---------------------------------------------------------------------------
+Write-Step "Staging artifacts"
+$staging = Join-Path $repoRoot "installer\staging"
+if (Test-Path $staging) { Remove-Item -Recurse -Force $staging }
+New-Item -ItemType Directory -Path $staging | Out-Null
+
+# Service binary
+$svcExe = Join-Path $repoRoot "service\target\release\stream-to-speaker.exe"
+if (-not (Test-Path $svcExe)) { throw "Service binary not found at $svcExe" }
+Copy-Item $svcExe (Join-Path $staging "stream-to-speaker.exe")
+
+# Driver files — scan the build tree for .sys / .inf / .cat with the
+# expected basenames so we tolerate WDK output-path variation.
+$driverRoot = Join-Path $repoRoot "driver\x64\$Configuration"
+$wanted = @("StreamToSpeaker.sys", "StreamToSpeaker.inf", "StreamToSpeaker.cat")
+foreach ($name in $wanted) {
+    $found = Get-ChildItem -Path $driverRoot -Recurse -Filter $name -ErrorAction SilentlyContinue `
+             | Select-Object -First 1
+    if ($found) {
+        Copy-Item $found.FullName (Join-Path $staging $name) -Force
+        Write-Host "  staged $($found.FullName)"
+    } else {
+        # Missing .cat is OK if the driver wasn't signed; missing .sys/.inf is fatal.
+        if ($name -eq "StreamToSpeaker.cat") {
+            Write-Host "  (skipping $name - not produced; the driver wasn't signed)"
+        } else {
+            throw "Required driver artifact $name not found under $driverRoot"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 4. Installer
+# ---------------------------------------------------------------------------
+if (-not $SkipInstaller) {
+    Write-Step "Building installer (Inno Setup)"
+    $isccCandidates = @(
+        "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+        "${env:ProgramFiles}\Inno Setup 6\ISCC.exe"
+    )
+    $iscc = $isccCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if (-not $iscc) {
+        throw "ISCC.exe (Inno Setup 6) not found. Install from https://jrsoftware.org/isdl.php - or 'choco install innosetup'."
+    }
+    $iss = Join-Path $repoRoot "installer\StreamToSpeaker.iss"
+    & $iscc "/DAppVersion=$Version" $iss
+    if ($LASTEXITCODE -ne 0) { throw "Installer build failed (exit $LASTEXITCODE)" }
+
+    $outDir = Join-Path $repoRoot "installer\out"
+    $artifact = Get-ChildItem -Path $outDir -Filter "StreamToSpeakerSetup-*.exe" `
+        | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($artifact) {
+        Write-Host ""
+        Write-Host "Installer: $($artifact.FullName)" -ForegroundColor Green
+        Write-Host "Size: $([math]::Round($artifact.Length / 1MB, 2)) MB" -ForegroundColor Green
+    }
+} else {
+    Write-Step "Skipping installer build (-SkipInstaller)"
+}
+
+Write-Host ""
+Write-Host "All steps complete." -ForegroundColor Green


### PR DESCRIPTION
Local build:
  .\installer\build-installer.ps1
produces installer\out\StreamToSpeakerSetup-<version>.exe — driver + service + endpoint-rename script in one file, with Start Menu / desktop / autostart options and a working uninstaller (kills the running process, removes the driver via pnputil by looking up the oem-assigned name).

CI: .github/workflows/build.yml runs on every push + PR + tag on windows-latest. Installs WDK from Microsoft's direct download (~5 min), Inno Setup via chocolatey, builds driver + service + installer, uploads both the .exe installer and the raw binaries as artifacts. On a 'v*' tag push, also attaches the installer to a GitHub Release with auto-generated notes.

Build steps stage all artifacts into installer\staging\ before ISCC runs, so the .iss has stable Source paths instead of being coupled to WDK/Cargo output-directory conventions that drift across toolchain versions.

Other:
- LICENSE (MIT) — README claimed MIT but the file was missing, and the installer's LicenseFile= directive needed something to point at
- README: 'Building the installer' + 'Continuous integration' sections
- .gitignore: installer/out + staging
