### PR TITLE
Installer: split VersionInfoVersion from AppVersion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # -----------------------------------------------------------------
-      # Compute a version string.  Tag push (v1.2.3) → 1.2.3.  Anything
-      # else → 0.1.0-<short-sha> or the workflow_dispatch input.
+      # Compute two version strings:
+      #   version   — free-form, used in filename + display ("0.1.0-abc1234")
+      #   viversion — strict X.Y.Z.W numeric, required for the Win32
+      #               VersionInfo resource Inno Setup bakes into setup.exe
+      # Tag push  v1.2.3   → version 1.2.3,        viversion 1.2.3.0
+      # Otherwise          → version 0.1.0-<sha>,  viversion 0.1.0.0
       # -----------------------------------------------------------------
       - name: Compute version
         id: ver
@@ -46,8 +50,16 @@ jobs:
               $sha = "${{ github.sha }}".Substring(0, 7)
               $v = "0.1.0-$sha"
           }
-          Write-Host "Version: $v"
+          # Numeric prefix of $v, padded to 4 parts.
+          $prefix = ($v -split "[-+]")[0]
+          $parts = $prefix -split "\."
+          while ($parts.Count -lt 4) { $parts += "0" }
+          # Strip any non-numeric parts (paranoia — Inno rejects them).
+          $parts = $parts | ForEach-Object { if ($_ -match "^\d+$") { $_ } else { "0" } }
+          $vi = $parts[0..3] -join "."
+          Write-Host "version=$v  viversion=$vi"
           "version=$v" >> $env:GITHUB_OUTPUT
+          "viversion=$vi" >> $env:GITHUB_OUTPUT
 
       # -----------------------------------------------------------------
       # Toolchains
@@ -141,7 +153,10 @@ jobs:
         run: |
           $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
           if (-not (Test-Path $iscc)) { throw "ISCC not at $iscc" }
-          & $iscc "/DAppVersion=${{ steps.ver.outputs.version }}" "installer\StreamToSpeaker.iss"
+          & $iscc `
+            "/DAppVersion=${{ steps.ver.outputs.version }}" `
+            "/DVersionInfoVersion=${{ steps.ver.outputs.viversion }}" `
+            "installer\StreamToSpeaker.iss"
           if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit $LASTEXITCODE" }
 
       # -----------------------------------------------------------------

--- a/installer/StreamToSpeaker.iss
+++ b/installer/StreamToSpeaker.iss
@@ -24,9 +24,17 @@
 #define MyAppName        "Stream To Speaker"
 #define MyAppShortName   "StreamToSpeaker"
 #define MyAppExeName     "stream-to-speaker.exe"
+; AppVersion: free-form (e.g. "0.1.0", "0.1.0-rc.1", "0.1.0-abcdef0").
 ; Override on the command line: ISCC /DAppVersion=0.1.0
 #ifndef AppVersion
   #define AppVersion     "0.1.0"
+#endif
+; VersionInfoVersion: strict X.Y.Z.W numeric — required by the Win32
+; resource format. The build script / CI derives this from AppVersion's
+; numeric prefix and passes it separately so pre-release suffixes
+; ("-rc.1", "-abc1234") don't break the compile.
+#ifndef VersionInfoVersion
+  #define VersionInfoVersion "0.1.0.0"
 #endif
 #define MyAppPublisher   "Stream To Speaker"
 #define MyAppURL         "https://github.com/Mihonarium/StreamToSpeaker"
@@ -41,7 +49,7 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}/issues
 AppUpdatesURL={#MyAppURL}/releases
-VersionInfoVersion={#AppVersion}
+VersionInfoVersion={#VersionInfoVersion}
 DefaultDirName={autopf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes

--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -136,8 +136,17 @@ if (-not $SkipInstaller) {
     if (-not $iscc) {
         throw "ISCC.exe (Inno Setup 6) not found. Install from https://jrsoftware.org/isdl.php - or 'choco install innosetup'."
     }
+    # Derive the strict X.Y.Z.W numeric version that the PE resource
+    # format requires — Inno's VersionInfoVersion rejects pre-release
+    # suffixes like "-rc.1" or "-abc1234".
+    $prefix = ($Version -split "[-+]")[0]
+    $parts = $prefix -split "\."
+    while ($parts.Count -lt 4) { $parts += "0" }
+    $parts = $parts | ForEach-Object { if ($_ -match "^\d+$") { $_ } else { "0" } }
+    $viVersion = ($parts[0..3]) -join "."
+
     $iss = Join-Path $repoRoot "installer\StreamToSpeaker.iss"
-    & $iscc "/DAppVersion=$Version" $iss
+    & $iscc "/DAppVersion=$Version" "/DVersionInfoVersion=$viVersion" $iss
     if ($LASTEXITCODE -ne 0) { throw "Installer build failed (exit $LASTEXITCODE)" }
 
     $outDir = Join-Path $repoRoot "installer\out"


### PR DESCRIPTION
Inno's VersionInfoVersion directive maps to the Win32 PE resource and requires strict X.Y.Z.W numeric form. The CI version computation was emitting '0.1.0-<short-sha>' for non-tag pushes; ISCC then rejected that on line 44 with 'Value of [Setup] section directive "VersionInfoVersion" is invalid.'

Fix: pass two defines.
- /DAppVersion=<free-form>   — display + filename, may include suffix
- /DVersionInfoVersion=<X.Y.Z.W>  — numeric, used only for the PE resource

Both the CI workflow and the local build-installer.ps1 derive the numeric variant from AppVersion's leading numeric components (padded to 4 parts, non-numerics replaced with 0).
