### PR TITLE
Fix: device install via devcon, Quit actually quits, hide console window

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,16 @@ jobs:
                   throw "Required driver artifact $name not found"
               }
           }
+          # devcon.exe — needed at install time to add the root-enumerated
+          # StreamToSpeaker device. Bundled with the WDK we just installed.
+          $devcon = Get-ChildItem `
+              -Path "C:\Program Files (x86)\Windows Kits\10\Tools" `
+              -Recurse -Filter "devcon.exe" -ErrorAction SilentlyContinue `
+              | Where-Object { $_.FullName -match "\\x64\\" } `
+              | Select-Object -First 1
+          if (-not $devcon) { throw "devcon.exe not found under WDK Tools" }
+          Copy-Item $devcon.FullName "$staging\devcon.exe" -Force
+          Write-Host "Staged $($devcon.FullName)"
 
       - name: Build installer (Inno Setup)
         shell: pwsh

--- a/installer/StreamToSpeaker.iss
+++ b/installer/StreamToSpeaker.iss
@@ -96,6 +96,15 @@ Source: "{#SourcePath}\staging\StreamToSpeaker.cat"; DestDir: "{app}\driver"; Fl
 Source: "{#SourcePath}\..\scripts\Rename-Endpoint.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
 Source: "{#SourcePath}\Uninstall-Driver.ps1";           DestDir: "{app}\scripts"; Flags: ignoreversion
 
+; --- devcon.exe (WDK redistributable, MIT) ---
+; Used to add the root-enumerated StreamToSpeaker device after the
+; driver package is staged. pnputil /add-driver /install stages
+; drivers and matches them against EXISTING devices; root-enumerated
+; devices have to be inserted explicitly with devcon (or the
+; SetupDi API). Without this step the driver sits in the store but
+; no audio endpoint ever appears in Sound Settings.
+Source: "{#SourcePath}\staging\devcon.exe"; DestDir: "{app}\driver"; Flags: ignoreversion
+
 ; --- Docs ---
 Source: "{#SourcePath}\..\README.md"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#SourcePath}\..\LICENSE";   DestDir: "{app}"; Flags: ignoreversion
@@ -116,15 +125,22 @@ Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
     Tasks: autostart; Flags: uninsdeletevalue
 
 [Run]
-; 1) Install the driver package. pnputil stages it into DriverStore and,
-;    when the INF describes a Root-enumerated device on Win10 1809+,
-;    creates the device automatically. Output captured via /subst-args.
+; 1) Stage the driver package in the DriverStore.
 Filename: "{sys}\pnputil.exe"; \
     Parameters: "/add-driver ""{app}\driver\StreamToSpeaker.inf"" /install"; \
-    StatusMsg: "Installing audio driver..."; \
+    StatusMsg: "Staging audio driver..."; \
     Flags: runhidden waituntilterminated
 
-; 2) Overwrite the cached endpoint friendly name (the Windows registry
+; 2) Insert the root-enumerated device. This is what makes "Stream To
+;    Speaker" appear in Windows Sound Settings — pnputil only stages
+;    the driver, the device still has to be created. devcon install
+;    is idempotent: if the device already exists it just no-ops.
+Filename: "{app}\driver\devcon.exe"; \
+    Parameters: "install ""{app}\driver\StreamToSpeaker.inf"" Root\StreamToSpeaker"; \
+    StatusMsg: "Creating audio device..."; \
+    Flags: runhidden waituntilterminated
+
+; 3) Overwrite the cached endpoint friendly name (the Windows registry
 ;    keeps the auto-generated "Internal AUX Jack ..." string across
 ;    reinstalls; this script writes the same slot Sound Settings'
 ;    Rename button writes to).
@@ -133,7 +149,7 @@ Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
     StatusMsg: "Naming the audio endpoint..."; \
     Flags: runhidden waituntilterminated
 
-; 3) Offer to launch the app at the end of install.
+; 4) Offer to launch the app at the end of install.
 Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; \
     Flags: nowait postinstall skipifsilent
 
@@ -141,6 +157,10 @@ Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; \
 ; Kill any running instance before yanking the driver out from under it.
 Filename: "{sys}\taskkill.exe"; Parameters: "/F /IM {#MyAppExeName}"; \
     Flags: runhidden; RunOnceId: "KillService"
+
+; Remove the device(s) so the driver isn't pinned by an active node.
+Filename: "{app}\driver\devcon.exe"; Parameters: "remove Root\StreamToSpeaker"; \
+    Flags: runhidden waituntilterminated; RunOnceId: "RemoveDevice"
 
 ; Remove the driver package. pnputil /delete-driver expects the OEM-
 ; assigned name (oemNN.inf) which we don't know up front, so we shell

--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -123,6 +123,22 @@ foreach ($name in $wanted) {
     }
 }
 
+# devcon.exe from the WDK — needed at install time to add the
+# root-enumerated StreamToSpeaker device. Search common WDK locations
+# and copy the x64 build into the staging dir.
+$devconCandidates = Get-ChildItem `
+    -Path "C:\Program Files (x86)\Windows Kits\10\Tools" `
+    -Recurse `
+    -Filter "devcon.exe" `
+    -ErrorAction SilentlyContinue `
+    | Where-Object { $_.FullName -match "\\x64\\" }
+$devcon = $devconCandidates | Select-Object -First 1
+if (-not $devcon) {
+    throw "devcon.exe not found in the WDK install (looked under C:\Program Files (x86)\Windows Kits\10\Tools)."
+}
+Copy-Item $devcon.FullName (Join-Path $staging "devcon.exe") -Force
+Write-Host "  staged $($devcon.FullName)"
+
 # ---------------------------------------------------------------------------
 # 4. Installer
 # ---------------------------------------------------------------------------

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -55,6 +55,8 @@ features = [
     "Win32_System_Performance",
     "Win32_System_Com",
     "Win32_System_SystemServices",
+    "Win32_System_Console",
+    "Win32_UI_WindowsAndMessaging",
 ]
 
 [profile.release]

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -256,10 +256,18 @@ fn run_headless(app: Arc<App>, source: Box<dyn AudioSource>) -> Result<()> {
 
 #[cfg(windows)]
 fn run_gui_mode(app: Arc<App>, source: Box<dyn AudioSource>, no_tray: bool) -> Result<()> {
+    // Hide the console window the C runtime allocates for us. The
+    // GUI window + tray icon are the user-facing surface; the console
+    // is just noise. We don't FreeConsole because that would close
+    // a parent terminal too if the user launched us from one — we
+    // just hide the window. (In --headless mode this code path isn't
+    // reached, so terminal users keep their console.)
+    hide_console_window();
+
     // Audio loop on a dedicated thread so it can MMCSS itself without
     // interfering with the GUI event loop.
     let audio_app = app.clone();
-    let audio_thread = thread::Builder::new()
+    let _audio_thread = thread::Builder::new()
         .name("stream-to-speaker-audio".to_string())
         .spawn(move || {
             if let Err(e) = audio_loop::run(audio_app.clone(), source) {
@@ -273,11 +281,27 @@ fn run_gui_mode(app: Arc<App>, source: Box<dyn AudioSource>, no_tray: bool) -> R
         warn!("GUI exited with error: {:#}", e);
     }
 
-    // Tell the audio loop to stop and wait for it.
+    // Tell the audio loop to stop. We deliberately do NOT join() it:
+    // it's blocked inside the kernel IOCTL (recv_packet) waiting for
+    // the next audio packet, and joining would hang until the next
+    // packet arrives — which on a paused / idle Sonos can be forever.
+    // Process termination kills the thread cleanly; the kernel handle
+    // is RAII-dropped via the SharedHandle Arc on exit.
     app.request_shutdown();
-    let _ = audio_thread.join();
     shutdown_cleanup(&app);
     Ok(())
+}
+
+#[cfg(windows)]
+fn hide_console_window() {
+    use windows_sys::Win32::System::Console::GetConsoleWindow;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE};
+    unsafe {
+        let hwnd = GetConsoleWindow();
+        if !hwnd.is_null() {
+            ShowWindow(hwnd, SW_HIDE);
+        }
+    }
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Three production bugs from the first real install on a clean machine.

## 1. Driver installed but no audio device appeared in Sound Settings

`pnputil /add-driver /install` stages a driver and matches it against *existing* devices. Our INF declares a **root-enumerated** device (`Root\StreamToSpeaker`), which means the device has to be *explicitly inserted* — pnputil never inserts one, even on Win10 1809+. Without that step the driver sits in the store but no audio endpoint comes into existence.

**Fix**: bundle `devcon.exe` (WDK redistributable, MIT) in the installer. Right after the pnputil staging step, run

```
devcon install StreamToSpeaker.inf Root\StreamToSpeaker
```

`devcon install` is idempotent — second run on the same machine just no-ops. The uninstaller now also runs `devcon remove Root\StreamToSpeaker` first, so the driver isn't pinned by a live device node when `pnputil /delete-driver` runs.

Both build paths stage `devcon.exe` from the WDK Tools tree — local `build-installer.ps1` searches under `C:\Program Files (x86)\Windows Kits\10\Tools` for the x64 build, the CI workflow does the same after WDK install (which is now cached, so the cost is just a `Copy-Item`).

## 2. Quit didn't quit; console window lingered

Two coupled bugs:

- The audio thread blocks indefinitely inside the kernel IOCTL `recv_packet`. `audio_thread.join()` after the GUI exited therefore hung forever — the next IOCTL completion only arrives when the speaker pulls more data, which on an idle / unselected speaker is never. **Fix**: skip the `join()` entirely. The process exit reaps the thread; the kernel handle is RAII-dropped via the `SharedHandle` Arc.

- `windows_subsystem = "console"` (Rust default) means a console window accompanies the GUI. Even after fixing the hang the console would have remained. **Fix**: hide it in GUI mode via `ShowWindow(GetConsoleWindow(), SW_HIDE)`. We don't `FreeConsole()` because that would close a parent terminal too if the user launched us from one; `ShowWindow(…, SW_HIDE)` only hides the console window itself. `--headless` skips the hide, so terminal users keep their log output.

## 3. BSOD

Needs the minidump to diagnose — please check `C:\Windows\Minidump\` for a `.dmp` file from around the time of the crash, and either upload it or paste the bugcheck code from BlueScreenView / WhoCrashed. The two cancel-path races we fixed earlier (commit 638a97b on `main`) might not be the only ones, but without the stack trace I can't aim a fix.

## Verified

Both Linux `cargo check` and Windows cross-compile (`x86_64-pc-windows-gnu`) build cleanly with no warnings.

---
