### PR TITLE
Fix Rescan button + CI SHA256 hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,6 +288,38 @@ jobs:
             "installer\StreamToSpeaker.iss"
           if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit $LASTEXITCODE" }
 
+      # Compute SHA256 of every shipped artifact so users can verify
+      # downloads. Hashes go three places:
+      #   - Job log (visible in raw CI output)
+      #   - GitHub step summary (rendered at the top of the workflow run
+      #     page — users can read it without expanding any step)
+      #   - .sha256 sidecar files alongside the .exe (attached to the
+      #     GitHub Release on tag pushes and uploaded as artifacts)
+      - name: Compute artifact SHA256 hashes
+        shell: pwsh
+        run: |
+          $items = @(
+              Get-ChildItem -Path "installer\out" -Filter "StreamToSpeakerSetup-*.exe" -ErrorAction SilentlyContinue
+              Get-Item "service\target\release\stream-to-speaker.exe" -ErrorAction SilentlyContinue
+              Get-ChildItem -Path "driver\x64\Release" -Recurse -Filter "StreamToSpeaker.sys" -ErrorAction SilentlyContinue | Select-Object -First 1
+          ) | Where-Object { $_ }
+          if (-not $items) { throw "No artifacts found to hash" }
+
+          $summary = @()
+          $summary += "## SHA256 hashes"
+          $summary += ""
+          $summary += "| File | SHA256 |"
+          $summary += "| --- | --- |"
+          foreach ($item in $items) {
+              $hash = (Get-FileHash -Algorithm SHA256 -Path $item.FullName).Hash.ToLower()
+              Write-Host "$hash  $($item.Name)"
+              # Sidecar file in the standard `<hash>  <filename>` shasum format.
+              $sidecar = "$($item.FullName).sha256"
+              "$hash  $($item.Name)" | Set-Content -Path $sidecar -Encoding ascii -NoNewline
+              $summary += "| ``$($item.Name)`` | ``$hash`` |"
+          }
+          $summary -join "`n" | Add-Content -Path $env:GITHUB_STEP_SUMMARY -Encoding utf8
+
       # -----------------------------------------------------------------
       # Publish
       # -----------------------------------------------------------------
@@ -295,7 +327,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: StreamToSpeakerSetup-${{ steps.ver.outputs.version }}
-          path: installer/out/StreamToSpeakerSetup-*.exe
+          path: |
+            installer/out/StreamToSpeakerSetup-*.exe
+            installer/out/StreamToSpeakerSetup-*.exe.sha256
           if-no-files-found: error
           retention-days: 30
 
@@ -308,11 +342,14 @@ jobs:
             driver/x64/Release/StreamToSpeaker/StreamToSpeaker.inf
             driver/x64/Release/StreamToSpeaker/StreamToSpeaker.cat
             service/target/release/stream-to-speaker.exe
+            service/target/release/stream-to-speaker.exe.sha256
           if-no-files-found: warn
 
       - name: Attach to GitHub Release (tag push only)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: installer/out/StreamToSpeakerSetup-*.exe
+          files: |
+            installer/out/StreamToSpeakerSetup-*.exe
+            installer/out/StreamToSpeakerSetup-*.exe.sha256
           generate_release_notes: true

--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -143,6 +143,23 @@ impl App {
         self.session.lock().unwrap().as_ref().map(|s| s.renderer.clone())
     }
 
+    /// Trigger an immediate SSDP re-scan. The discovery background
+    /// thread wakes up right away, runs one `discover_once`, then
+    /// resumes its regular periodic schedule. No-op (returns false) if
+    /// discovery is disabled (`--no-discovery`).
+    pub fn request_rescan(&self) -> bool {
+        match self.discovery.as_ref() {
+            Some(d) => { d.request_rescan(); true }
+            None => false,
+        }
+    }
+
+    /// True while the SSDP thread is mid-scan. The GUI uses this to
+    /// render a "Scanning…" hint after the user clicks Rescan.
+    pub fn is_scanning(&self) -> bool {
+        self.discovery.as_ref().map(|d| d.is_scanning()).unwrap_or(false)
+    }
+
     // -------------------------------------------------------------------
     // Speaker actions
     // -------------------------------------------------------------------

--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -637,11 +637,17 @@ impl StreamToSpeakerApp {
 
     fn show_speakers(&self, ui: &mut egui::Ui, p: &Palette) {
         card(ui, p, |ui| {
+            let scanning = self.app.is_scanning();
             ui.horizontal(|ui| {
                 section_label(ui, p, "Speakers");
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    secondary_button(ui, p, "↻  Rescan", 92.0)
-                        .on_hover_text("Re-trigger SSDP discovery now (otherwise runs every few minutes)");
+                    let label = if scanning { "↻  Scanning…" } else { "↻  Rescan" };
+                    let resp = ui.add_enabled_ui(!scanning, |ui| {
+                        secondary_button(ui, p, label, 100.0)
+                    }).inner;
+                    resp.on_hover_text("Re-trigger SSDP discovery now (otherwise runs every few minutes)")
+                        .clicked()
+                        .then(|| { self.app.request_rescan(); });
                 });
             });
             ui.add_space(6.0);
@@ -649,8 +655,13 @@ impl StreamToSpeakerApp {
             let view = self.app.speaker_view();
             if view.speakers.is_empty() {
                 ui.add_space(4.0);
+                let msg = if scanning {
+                    "Scanning the network for speakers…"
+                } else {
+                    "Searching the network for speakers…"
+                };
                 ui.label(
-                    egui::RichText::new("Searching the network for speakers…")
+                    egui::RichText::new(msg)
                         .color(p.text_secondary)
                         .italics(),
                 );

--- a/service/src/ssdp.rs
+++ b/service/src/ssdp.rs
@@ -11,7 +11,8 @@ use log::{debug, info, warn};
 use socket2::{Domain, Protocol, Socket, Type};
 use std::io::{Read, Write};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream, UdpSocket};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -37,10 +38,17 @@ pub struct Renderer {
 }
 
 /// Shared discovery state.  The main loop owns one; the SSDP thread
-/// updates it.
+/// updates it. The condvar/`kick_pending` pair lets external callers
+/// (the GUI's Rescan button, the `/api/rescan` endpoint) wake the
+/// discovery thread immediately instead of waiting out the periodic
+/// interval. `scanning` is set while a discover_once call is in flight
+/// so the GUI can render a "Scanning…" hint.
 #[derive(Default)]
 pub struct DiscoveryState {
     inner: Mutex<Vec<Renderer>>,
+    kick_pending: Mutex<bool>,
+    kick_cv: Condvar,
+    scanning: AtomicBool,
 }
 
 impl DiscoveryState {
@@ -50,6 +58,34 @@ impl DiscoveryState {
 
     pub fn renderers(&self) -> Vec<Renderer> {
         self.inner.lock().unwrap().clone()
+    }
+
+    /// True while a discover_once call is running. GUI polls this to
+    /// show feedback after a Rescan click.
+    pub fn is_scanning(&self) -> bool {
+        self.scanning.load(Ordering::Acquire)
+    }
+
+    /// Wake the discovery thread so it runs `discover_once` immediately
+    /// instead of waiting for the periodic timer. Cheap and idempotent —
+    /// rapid double-clicks just collapse into a single re-scan.
+    pub fn request_rescan(&self) {
+        *self.kick_pending.lock().unwrap() = true;
+        self.kick_cv.notify_all();
+    }
+
+    /// Block up to `timeout` for a kick. Returns true if kicked
+    /// (consumes the pending flag), false on timeout. Used by the
+    /// discovery thread between scans.
+    pub fn wait_for_kick(&self, timeout: Duration) -> bool {
+        let mut pending = self.kick_pending.lock().unwrap();
+        if !*pending {
+            let (p, _) = self.kick_cv.wait_timeout(pending, timeout).unwrap();
+            pending = p;
+        }
+        let kicked = *pending;
+        *pending = false;
+        kicked
     }
 
     /// Set the renderer list, deduping by control URL.
@@ -126,6 +162,7 @@ pub fn spawn_discovery(state: Arc<DiscoveryState>, interval: Duration, iface: Op
     thread::Builder::new()
         .name("stream-to-speaker-ssdp".to_string())
         .spawn(move || loop {
+            state.scanning.store(true, Ordering::Release);
             match discover_once(Duration::from_secs(3), iface) {
                 Ok(found) => {
                     info!("SSDP discovery: {} renderer(s) found", found.len());
@@ -133,7 +170,11 @@ pub fn spawn_discovery(state: Arc<DiscoveryState>, interval: Duration, iface: Op
                 }
                 Err(e) => warn!("SSDP discovery failed: {}", e),
             }
-            thread::sleep(interval);
+            state.scanning.store(false, Ordering::Release);
+            // Wait the regular interval, but wake early on rescan.
+            if state.wait_for_kick(interval) {
+                debug!("SSDP discovery kicked early by Rescan");
+            }
         })
         .expect("spawning SSDP thread");
 }


### PR DESCRIPTION
Two unrelated fixes:

## 1. Wire up the GUI Rescan button

The button rendered but its `.clicked()` response was never checked, so clicking did nothing — that's why "speakers that have not previously been available" never showed up after rescanning.

- `DiscoveryState` gains a kickable wait + scanning flag. The SSDP thread now sleeps on a condvar (`wait_for_kick`) instead of `thread::sleep`, so `request_rescan()` wakes it immediately. Rapid clicks collapse to a single re-scan.
- `App::request_rescan()` / `App::is_scanning()` expose this to the GUI.
- Button click now calls `app.request_rescan()`; the label flips to **"Scanning…"** and the empty-state hint updates while a scan is in flight. The button disables itself during the scan so we don't spam the SSDP thread.

## 2. CI: print SHA256 hashes for download verification

Hashes are surfaced three ways:
- **Job log** — `Get-FileHash` output for the installer, service `.exe`, and driver `.sys`
- **Workflow run summary** — markdown table at the top of the Actions run page (no need to expand a step)
- **`.sha256` sidecar files** in standard `<hash>  <filename>` shasum format
  - Uploaded as artifacts alongside the `.exe`s
  - Attached to GitHub Releases on `v*` tag pushes (so the Release page lists `StreamToSpeakerSetup-X.Y.Z.exe` next to `StreamToSpeakerSetup-X.Y.Z.exe.sha256`)

Users can verify with `Get-FileHash StreamToSpeakerSetup-X.Y.Z.exe` on Windows or `sha256sum -c StreamToSpeakerSetup-X.Y.Z.exe.sha256` on Linux/macOS.
