### PR TITLE
Endpoint classification, hide-to-tray, auto-reconnect, and a pile of UX fixes

### DIFF
--- a/service/Cargo.lock
+++ b/service/Cargo.lock
@@ -1559,6 +1559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jiff"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +2796,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,6 +2978,8 @@ dependencies = [
  "quick-xml 0.36.2",
  "raw-window-handle",
  "roxmltree",
+ "serde",
+ "serde_json",
  "socket2",
  "thiserror 1.0.69",
  "tiny_http",
@@ -3977,3 +3998,9 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -31,6 +31,11 @@ socket2 = { version = "0.5", features = ["all"] }
 byteorder = "1"
 url = "2"
 percent-encoding = "2"
+# Persisted user preferences live in %APPDATA%\StreamToSpeaker\config.json
+# (last selected speaker, onboarding dismissal). Tiny surface, serde is
+# the obvious fit.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
 # WASAPI loopback fallback. cpal supports WASAPI loopback on Windows.

--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -16,6 +16,7 @@ use crate::gena::GenaManager;
 use crate::http_server::{SpeakerInfo, StreamHub};
 use crate::silence::DEFAULT_QUIESCENT_AFTER_PACKETS;
 use crate::ssdp::{DiscoveryState, Renderer};
+use crate::user_config::UserConfig;
 use crate::volume_sync::VolumeSync;
 use crate::{upnp, PRODUCT_NAME, WIRE_SAMPLE_RATE};
 
@@ -95,16 +96,28 @@ pub struct App {
 
     // ---- Lifecycle ----
     pub shutdown: Arc<AtomicBool>,
+
+    /// Persisted user preferences (last picked speaker, onboarding
+    /// dismissal). Loaded from disk in `App::new` and saved back via
+    /// `App::save_user_config` whenever it changes. Behind a Mutex
+    /// because saves happen lazily from any thread (GUI click,
+    /// auto-reconnect bg thread, ...).
+    pub user_config: Mutex<UserConfig>,
 }
 
 impl App {
     pub fn new(config: AppConfig, discovery: Option<Arc<DiscoveryState>>) -> Arc<Self> {
         let web_initial = config.web_enabled;
+        let user_config = UserConfig::load();
+        // Seed last_speaker_id from disk so that, even before any user
+        // action, code that asks "what was the last speaker?" gets the
+        // persisted answer.
+        let last_speaker_id = Mutex::new(user_config.last_speaker_id.clone());
         Arc::new(Self {
             config,
             discovery,
             session: Arc::new(Mutex::new(None)),
-            last_speaker_id: Mutex::new(None),
+            last_speaker_id,
             hub: StreamHub::new(),
             vsync: Arc::new(VolumeSync::new()),
             stream_active: Arc::new(AtomicBool::new(true)),
@@ -117,7 +130,31 @@ impl App {
             packets_published_total: Arc::new(AtomicU64::new(0)),
             started_at: Instant::now(),
             shutdown: Arc::new(AtomicBool::new(false)),
+            user_config: Mutex::new(user_config),
         })
+    }
+
+    /// Returns true if the user has dismissed the onboarding card.
+    /// Persisted across launches via `user_config`.
+    pub fn is_onboarding_dismissed(&self) -> bool {
+        self.user_config.lock().unwrap().onboarding_dismissed
+    }
+
+    /// Mark the onboarding card as dismissed and persist immediately.
+    pub fn dismiss_onboarding(&self) {
+        let mut uc = self.user_config.lock().unwrap();
+        if !uc.onboarding_dismissed {
+            uc.onboarding_dismissed = true;
+            uc.save();
+        }
+    }
+
+    /// The user's last explicitly-selected speaker, as persisted in
+    /// `user_config`. Returns `None` on a fresh install (which is what
+    /// makes `main.rs` skip auto-reconnect on the first launch — the
+    /// user picks manually that one time).
+    pub fn saved_speaker_id(&self) -> Option<String> {
+        self.user_config.lock().unwrap().last_speaker_id.clone()
     }
 
     // -------------------------------------------------------------------
@@ -180,6 +217,16 @@ impl App {
         *guard = Some(new_session);
         *self.last_speaker_id.lock().unwrap() = Some(id.to_string());
         self.streaming_enabled.store(true, Ordering::Release);
+        // Persist so the next launch can auto-reconnect to this speaker.
+        // Saved as a side-effect of an explicit pick — see
+        // user_config.rs for the file location.
+        {
+            let mut uc = self.user_config.lock().unwrap();
+            if uc.last_speaker_id.as_deref() != Some(id) {
+                uc.last_speaker_id = Some(id.to_string());
+                uc.save();
+            }
+        }
         Ok(())
     }
 

--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -7,7 +7,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use log::{debug, info, warn};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -44,6 +44,10 @@ pub struct AppConfig {
     pub no_silence_injection: bool,
     pub no_discovery: bool,
     pub web_enabled: bool,
+    /// Local IPv4 interface the SSDP scanner binds to (same iface the
+    /// periodic discovery loop uses). Stored so the GUI's Rescan button
+    /// can fire a one-shot scan on the same network.
+    pub ssdp_iface: Option<Ipv4Addr>,
 }
 
 /// Snapshot of the speaker list + currently-active id. Cheap to compute
@@ -177,6 +181,31 @@ impl App {
         *self.last_speaker_id.lock().unwrap() = Some(id.to_string());
         self.streaming_enabled.store(true, Ordering::Release);
         Ok(())
+    }
+
+    /// Fire a one-shot SSDP M-SEARCH on the same interface the periodic
+    /// loop uses. Runs on a detached thread because `discover_once`
+    /// blocks for ~3 s waiting for responses; the GUI button doesn't
+    /// want to freeze. Results land in `DiscoveryState::replace` and
+    /// are picked up by the next `speaker_view()` call.
+    pub fn trigger_rescan(&self) {
+        let Some(discovery) = self.discovery.clone() else {
+            warn!("trigger_rescan: discovery disabled");
+            return;
+        };
+        let iface = self.config.ssdp_iface;
+        std::thread::Builder::new()
+            .name("stream-to-speaker-rescan".to_string())
+            .spawn(move || {
+                match crate::ssdp::discover_once(Duration::from_secs(3), iface) {
+                    Ok(found) => {
+                        info!("manual rescan: {} renderer(s) found", found.len());
+                        discovery.replace(found);
+                    }
+                    Err(e) => warn!("manual rescan failed: {}", e),
+                }
+            })
+            .ok();
     }
 
     /// Resync — UPnP Stop+Play on the current speaker. Drops Sonos's

--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -780,8 +780,12 @@ impl StreamToSpeakerApp {
             ui.horizontal(|ui| {
                 section_label(ui, p, "Speakers");
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    secondary_button(ui, p, "↻  Rescan", 92.0)
-                        .on_hover_text("Re-trigger SSDP discovery now (otherwise runs every few minutes)");
+                    if secondary_button(ui, p, "↻  Rescan", 92.0)
+                        .on_hover_text("Re-trigger SSDP discovery now (otherwise runs every few minutes)")
+                        .clicked()
+                    {
+                        self.app.trigger_rescan();
+                    }
                 });
             });
             ui.add_space(6.0);

--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -438,8 +438,15 @@ impl eframe::App for StreamToSpeakerApp {
                         .show(ui, |ui| {
                             self.show_status_banner(ui, &p);
                             ui.add_space(14.0);
-                            if self.app.current_renderer().is_none()
-                                && !self.onboarding_dismissed
+                            // Show onboarding regardless of whether a
+                            // speaker is currently bound, until the
+                            // user explicitly dismisses with "Got it".
+                            // Dismissal is persisted via user_config
+                            // (see app.rs::dismiss_onboarding), so
+                            // returning users don't see it on every
+                            // launch.
+                            if !self.onboarding_dismissed
+                                && !self.app.is_onboarding_dismissed()
                             {
                                 self.show_onboarding(ui, &p);
                                 ui.add_space(14.0);
@@ -612,10 +619,11 @@ impl StreamToSpeakerApp {
                 section_label(ui, p, "Getting started");
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if secondary_button(ui, p, "Got it", 72.0)
-                        .on_hover_text("Hide this card for the rest of the session")
+                        .on_hover_text("Hide this card — won't show again on future launches")
                         .clicked()
                     {
                         self.onboarding_dismissed = true;
+                        self.app.dismiss_onboarding();
                     }
                 });
             });

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -16,6 +16,7 @@ pub mod volume_sync;
 pub mod sine_source;
 pub mod qpc;
 pub mod picker;
+pub mod user_config;
 #[cfg(windows)]
 pub mod wasapi_source;
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -260,12 +260,35 @@ fn run(cli: Cli) -> Result<()> {
     }
 
     // Resolve initial speaker.
+    //
+    // Priority chain:
+    //   1. `--player <hint>`  — explicit override, fuzzy match
+    //   2. interactive headless TTY — prompt the user
+    //   3. saved speaker id from user_config — auto-reconnect to the
+    //      one the user last explicitly picked
+    //   4. otherwise — DON'T auto-select. The GUI's onboarding card
+    //      kicks in so the user picks manually one time; their
+    //      choice gets persisted and step 3 takes over from then on.
+    //
+    // The old fallback ("first discovered") was the reason GUI users
+    // never got to see the onboarding card and ended up with a random
+    // speaker bound at launch.
     if !cli.no_discovery {
-        let initial = picker::resolve(
-            app.discovery.as_ref().unwrap(),
-            cli.player.as_deref(),
-            !cli.no_interactive && cli.headless,
-        )?;
+        let discovery = app.discovery.as_ref().unwrap();
+        let initial = if cli.player.is_some() {
+            picker::resolve(discovery, cli.player.as_deref(), false)?
+        } else if !cli.no_interactive && cli.headless {
+            picker::resolve(discovery, None, true)?
+        } else if let Some(saved_id) = app.saved_speaker_id() {
+            info!("auto-reconnect: trying saved speaker {:?}", saved_id);
+            // Wait briefly for the first SSDP sweep to populate
+            // discovery before we look the saved id up.
+            picker::wait_for_first_discovery(discovery, Duration::from_secs(5));
+            discovery.find_by_id(&saved_id)
+        } else {
+            info!("first launch (no saved speaker) — waiting for manual pick");
+            None
+        };
         if let Some(r) = initial {
             let id = r.stable_id();
             if let Err(e) = app.select_speaker(&id) {

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -374,12 +374,16 @@ fn setup_app(cli: &Cli) -> Result<Arc<App>> {
         None => stream_to_speaker::app::default_advertise_ip()?,
     };
 
+    let ssdp_iface = if cli.no_discovery {
+        None
+    } else {
+        stream_to_speaker::app::pick_ssdp_iface(cli.advertise_ip.as_deref(), &cli.bind)
+    };
+
     let discovery = if cli.no_discovery {
         None
     } else {
         let state = DiscoveryState::new();
-        let ssdp_iface =
-            stream_to_speaker::app::pick_ssdp_iface(cli.advertise_ip.as_deref(), &cli.bind);
         spawn_discovery(
             state.clone(),
             Duration::from_secs(cli.ssdp_interval * 60),
@@ -401,6 +405,7 @@ fn setup_app(cli: &Cli) -> Result<Arc<App>> {
         no_silence_injection: cli.no_silence_injection,
         no_discovery: cli.no_discovery,
         web_enabled: cli.web,
+        ssdp_iface,
     };
 
     Ok(App::new(config, discovery))

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -29,7 +29,6 @@ use std::net::{IpAddr, SocketAddr};
 #[cfg(windows)]
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-#[cfg(windows)]
 use std::thread;
 use std::time::Duration;
 
@@ -259,6 +258,36 @@ fn run(cli: Cli) -> Result<()> {
         );
     }
 
+    // Driver-event consumer.
+    #[cfg(windows)]
+    spawn_driver_event_consumer(app.clone(), &cli);
+
+    // Ctrl-C handler — set the shutdown flag.
+    install_signal_handler(app.clone());
+
+    // Apply initial values from CLI to the runtime atomics.
+    app.set_silence_pace_ms(cli.silence_pace_ms);
+    app.set_rate_fudge_ppm(cli.rate_fudge_ppm);
+    app.set_latency_adjust_step_frames(cli.latency_adjust_step_frames);
+
+    // Start the audio loop BEFORE we issue any UPnP Play. With the
+    // old order (Play → spawn audio thread) the speaker connected to
+    // /stream.raw before the audio loop was producing data — Sonos
+    // would receive an empty HTTP body, time out, and stay in a
+    // "I'm connected but not playing" state until the user hit
+    // Resync. Spawning audio first means silence injection is already
+    // running by the time we send Play, so the speaker gets a
+    // populated stream from byte zero.
+    let audio_app = app.clone();
+    let _audio_thread = thread::Builder::new()
+        .name("stream-to-speaker-audio".to_string())
+        .spawn(move || {
+            if let Err(e) = audio_loop::run(audio_app.clone(), source) {
+                error!("audio loop exited with error: {:#}", e);
+            }
+        })
+        .context("spawning audio thread")?;
+
     // Resolve initial speaker.
     //
     // Priority chain:
@@ -301,56 +330,33 @@ fn run(cli: Cli) -> Result<()> {
         }
     }
 
-    // Driver-event consumer.
-    #[cfg(windows)]
-    spawn_driver_event_consumer(app.clone(), &cli);
-
-    // Ctrl-C handler — set the shutdown flag.
-    install_signal_handler(app.clone());
-
-    // Apply initial values from CLI to the runtime atomics.
-    app.set_silence_pace_ms(cli.silence_pace_ms);
-    app.set_rate_fudge_ppm(cli.rate_fudge_ppm);
-    app.set_latency_adjust_step_frames(cli.latency_adjust_step_frames);
-
     if cli.headless {
-        run_headless(app, source)
+        run_headless(app)
     } else {
-        run_gui_mode(app, source, cli.no_tray)
+        run_gui_mode(app, cli.no_tray)
     }
 }
 
 // -----------------------------------------------------------------------------
-// Headless run — audio loop on main thread
+// Headless run — block on shutdown signal; audio is on the bg thread
+// spawned in run() above.
 // -----------------------------------------------------------------------------
 
-fn run_headless(app: Arc<App>, source: Box<dyn AudioSource>) -> Result<()> {
-    audio_loop::run(app.clone(), source)?;
+fn run_headless(app: Arc<App>) -> Result<()> {
+    while !app.is_shutting_down() {
+        std::thread::sleep(Duration::from_millis(200));
+    }
     shutdown_cleanup(&app);
     Ok(())
 }
 
 // -----------------------------------------------------------------------------
-// GUI run — audio loop on background thread, eframe on main thread
+// GUI run — eframe on main thread; audio is on the bg thread spawned
+// in run() above.
 // -----------------------------------------------------------------------------
 
 #[cfg(windows)]
-fn run_gui_mode(app: Arc<App>, source: Box<dyn AudioSource>, no_tray: bool) -> Result<()> {
-    // No console-hiding needed: windows_subsystem = "windows" means
-    // we were never allocated one in the first place.
-
-    // Audio loop on a dedicated thread so it can MMCSS itself without
-    // interfering with the GUI event loop.
-    let audio_app = app.clone();
-    let _audio_thread = thread::Builder::new()
-        .name("stream-to-speaker-audio".to_string())
-        .spawn(move || {
-            if let Err(e) = audio_loop::run(audio_app.clone(), source) {
-                error!("audio loop exited with error: {:#}", e);
-            }
-        })
-        .context("spawning audio thread")?;
-
+fn run_gui_mode(app: Arc<App>, no_tray: bool) -> Result<()> {
     // Run the GUI (blocks until window/tray exits).
     if let Err(e) = stream_to_speaker::gui::run(app.clone(), !no_tray) {
         warn!("GUI exited with error: {:#}", e);
@@ -368,7 +374,7 @@ fn run_gui_mode(app: Arc<App>, source: Box<dyn AudioSource>, no_tray: bool) -> R
 }
 
 #[cfg(not(windows))]
-fn run_gui_mode(_app: Arc<App>, _source: Box<dyn AudioSource>, _no_tray: bool) -> Result<()> {
+fn run_gui_mode(_app: Arc<App>, _no_tray: bool) -> Result<()> {
     anyhow::bail!("GUI mode is Windows-only — pass --headless on this platform")
 }
 

--- a/service/src/tray.rs
+++ b/service/src/tray.rs
@@ -282,27 +282,42 @@ fn open_web_ui(advertise_ip: &str, port: u16) {
 // -----------------------------------------------------------------------------
 
 fn build_icon() -> Result<Icon> {
+    // 32×32 — Windows downsamples to 16×16 / 24×24 / 20×20 depending
+    // on DPI. Shapes need to be bold enough that downsampling doesn't
+    // collapse them into a featureless blob (which is what the
+    // previous design did, hence "it's a square").
     const W: u32 = 32;
     const H: u32 = 32;
     let mut pixels = vec![0u8; (W * H * 4) as usize];
-
-    let fg = [60u8, 180, 100, 255];
-    let bg = [16u8, 16, 16, 0]; // transparent
+    // Transparent background — all zeros (RGBA 0,0,0,0).
+    let fg = [60u8, 180, 100, 255]; // accent green, opaque
 
     for y in 0..H {
         for x in 0..W {
             let i = ((y * W + x) * 4) as usize;
-            let xc = x as i32 - 16;
-            let yc = y as i32 - 16;
-            let r2 = xc * xc + yc * yc;
-            let speaker_body = (xc.abs() <= 5 && yc.abs() <= 10)
-                || (r2 < 14 * 14 && xc > 5)
-                || (r2 < 6 * 6);
-            let color = if speaker_body { fg } else { bg };
-            pixels[i] = color[0];
-            pixels[i + 1] = color[1];
-            pixels[i + 2] = color[2];
-            pixels[i + 3] = color[3];
+            let xi = x as i32;
+            let yi = y as i32;
+
+            // 1. Speaker body — solid vertical rectangle on the left.
+            //    Width 7, height 11, centered vertically at y=16.
+            let body = xi >= 5 && xi <= 11 && yi >= 11 && yi <= 21;
+
+            // 2. Cone — trapezoid opening to the right, attaches to
+            //    the body's right edge. At x=11 the cone matches the
+            //    body's height; at x=22 it widens to fill 24 px
+            //    vertically.
+            //    half_height(dx) = 5 + dx * 7 / 11   (5 → 12, linear)
+            let cone_dx = xi - 11;
+            let half_h = 5 + (cone_dx * 7 + 5) / 11;
+            let cone =
+                cone_dx >= 0 && cone_dx <= 11 && (yi - 16).abs() <= half_h;
+
+            if body || cone {
+                pixels[i] = fg[0];
+                pixels[i + 1] = fg[1];
+                pixels[i + 2] = fg[2];
+                pixels[i + 3] = fg[3];
+            }
         }
     }
 

--- a/service/src/tray.rs
+++ b/service/src/tray.rs
@@ -1,16 +1,25 @@
 //! System tray icon + context menu.
 //!
 //! `muda`'s `MenuItem` is `!Send` (it holds an `Rc` internally), so the
-//! menu items live on the GUI's main thread. Tray + menu events are
-//! drained from the egui `update()` loop via `TrayHandle::pump`. The
-//! same loop also keeps the status label and check-state synced with
-//! the shared `App`.
+//! menu items themselves live on the GUI's main thread. `pump()` runs
+//! from the egui update loop and keeps the status label / check states
+//! synced.
+//!
+//! Tray + menu *events* are drained by a dedicated background thread,
+//! not by `pump()`. This is the fix for the "Show window from tray
+//! does nothing after minimize-to-tray" bug: egui's `update()` only
+//! runs in response to `WM_PAINT`, and a hidden window doesn't
+//! generate `WM_PAINT` — so if event draining lives in `pump()`, the
+//! Show-window menu click sits in the channel forever. The bg thread
+//! is unaffected by paint state and just calls `ShowWindow` directly
+//! when the click arrives.
 
 #![cfg(windows)]
 
 use anyhow::{anyhow, Result};
 use eframe::egui;
 use log::{info, warn};
+use std::sync::atomic::{AtomicIsize, Ordering};
 use std::sync::Arc;
 
 use tray_icon::{
@@ -30,21 +39,20 @@ pub struct TrayHandle {
     enable_toggle: CheckMenuItem,
     open_web_item: MenuItem,
 
-    // Ids used to route MenuEvents to actions.
-    ids: TrayIds,
-
     last_label: String,
     last_enabled: bool,
     last_web_enabled: bool,
 
-    // HWND of the GUI window, populated by gui::update on the first
-    // frame. We use raw Win32 ShowWindow to flip visibility because
-    // egui ViewportCommands don't drain on hidden viewports. Until
-    // set, Show window is a no-op (window is already visible on the
-    // very first frame anyway).
-    hwnd: Option<isize>,
+    /// HWND of the GUI window. Shared with the bg event thread; that
+    /// thread calls raw Win32 `ShowWindow` on it when the user clicks
+    /// the tray icon. Populated by `gui::run` once eframe has actually
+    /// created the OS window (zero means "not set yet" — the very
+    /// first frame is always visible, so the bg thread has nothing to
+    /// do until the window is hidden, which happens later).
+    hwnd: Arc<AtomicIsize>,
 }
 
+#[derive(Clone)]
 struct TrayIds {
     switch_speaker: MenuId,
     trim_25: MenuId,
@@ -128,36 +136,48 @@ pub fn spawn(app: Arc<App>, egui_ctx: egui::Context) -> Result<TrayHandle> {
         .build()
         .map_err(|e| anyhow!("tray-icon build: {}", e))?;
 
-    // `egui_ctx` is held by the periodic-repaint tick already; we just
-    // touch it here so the parameter isn't formally unused.
-    let _ = egui_ctx;
+    let hwnd = Arc::new(AtomicIsize::new(0));
+
+    // Spawn the bg event handler thread. It owns clones of the App
+    // Arc, the egui Context, the TrayIds (MenuId is Clone), and the
+    // shared HWND atomic. Runs until process exit.
+    {
+        let app = app.clone();
+        let ctx = egui_ctx.clone();
+        let ids = ids.clone();
+        let hwnd = hwnd.clone();
+        std::thread::Builder::new()
+            .name("stream-to-speaker-tray-events".to_string())
+            .spawn(move || event_loop(app, ctx, ids, hwnd))
+            .ok();
+    }
 
     Ok(TrayHandle {
         _icon: tray,
         status_item,
         enable_toggle,
         open_web_item: open_web,
-        ids,
         last_label: String::new(),
         last_enabled: app.is_streaming_enabled(),
         last_web_enabled: web_on,
-        hwnd: None,
+        hwnd,
     })
 }
 
 impl TrayHandle {
-    /// Set the HWND the tray uses to show / hide the window. Called by
-    /// gui::update on the first frame, once eframe has actually created
-    /// the OS window.
+    /// Set the HWND the bg event thread uses to show the window when
+    /// the user clicks the tray icon. Called by `gui::run` once eframe
+    /// has actually created the OS window (HWND is stable for the
+    /// lifetime of the window).
     pub fn set_hwnd(&mut self, hwnd: isize) {
-        self.hwnd = Some(hwnd);
+        self.hwnd.store(hwnd, Ordering::Relaxed);
     }
 
-    /// Drain pending tray and menu events, update the visible bits of
-    /// the menu (status label, check state) to reflect the App. Called
-    /// from `gui::update()` once per frame; cheap when there's nothing
-    /// to do.
-    pub fn pump(&mut self, app: &Arc<App>, ctx: &egui::Context) {
+    /// Update the visible bits of the menu (status label, check
+    /// states) to reflect the App. Called from `gui::update()` once
+    /// per frame; cheap when there's nothing to do. Event draining
+    /// happens on the bg event thread now (see module-level docs).
+    pub fn pump(&mut self, app: &Arc<App>, _ctx: &egui::Context) {
         // Sync the status label.
         let label = match app.current_renderer() {
             Some(r) => format!("▶ {}", r.friendly_name),
@@ -175,8 +195,7 @@ impl TrayHandle {
             self.last_enabled = enabled;
         }
 
-        // Sync the "Open web UI" item label + enabled state based on
-        // whether the runtime web-UI toggle is currently on.
+        // Sync the "Open web UI" item label + enabled state.
         let web_on = app.is_web_ui_enabled();
         if web_on != self.last_web_enabled {
             self.open_web_item.set_text(if web_on {
@@ -187,83 +206,112 @@ impl TrayHandle {
             self.open_web_item.set_enabled(web_on);
             self.last_web_enabled = web_on;
         }
-
-        // Drain menu events. The receiver is process-global; events
-        // from any tray icon in this process flow through it.
-        while let Ok(MenuEvent { id }) = MenuEvent::receiver().try_recv() {
-            self.handle_menu_event(&id, app, ctx);
-        }
-
-        // Drain tray-icon events: left-click → show window.
-        while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
-            if let TrayIconEvent::Click {
-                button: MouseButton::Left,
-                button_state: MouseButtonState::Up,
-                ..
-            } = ev
-            {
-                self.show_main_window(ctx);
-            }
-        }
     }
+}
 
-    fn handle_menu_event(&self, id: &MenuId, app: &Arc<App>, ctx: &egui::Context) {
-        if *id == self.ids.trim_25 {
-            app.adjust_latency(25);
-        } else if *id == self.ids.trim_100 {
-            app.adjust_latency(100);
-        } else if *id == self.ids.pad_25 {
-            app.adjust_latency(-25);
-        } else if *id == self.ids.pad_100 {
-            app.adjust_latency(-100);
-        } else if *id == self.ids.resync {
-            if let Err(e) = app.resync() {
-                warn!("resync failed: {}", e);
-            }
-        } else if *id == self.ids.enable {
-            let new_state = !app.is_streaming_enabled();
-            if let Err(e) = app.set_streaming_enabled(new_state) {
-                warn!("toggle failed: {}", e);
-            }
-        } else if *id == self.ids.switch_speaker || *id == self.ids.show_window {
-            self.show_main_window(ctx);
-        } else if *id == self.ids.open_web {
-            if app.is_web_ui_enabled() {
-                open_web_ui(&app.config.advertise_ip, app.config.bind.port());
-            }
-        } else if *id == self.ids.quit {
-            info!("tray: quit requested");
-            app.request_shutdown();
-            ctx.request_repaint();
-        }
-        ctx.request_repaint();
-    }
-
-    /// Bring the GUI window to the front. SetWindowPos with
-    /// SWP_SHOWWINDOW flips visibility AND lifts Z-order in one
-    /// synchronous call, sidestepping the eframe ViewportCommand
-    /// queue (which doesn't drain on hidden windows — emilk/egui#5229,
-    /// #3655). SW_RESTORE handles the minimised case. ShowWindowAsync
-    /// is used for SW_RESTORE so a tray-pump invocation from outside
-    /// the owning thread is still safe.
-    fn show_main_window(&self, ctx: &egui::Context) {
-        if let Some(hwnd) = self.hwnd {
-            use windows_sys::Win32::UI::WindowsAndMessaging::{
-                SetWindowPos, ShowWindowAsync, SetForegroundWindow, IsIconic,
-                HWND_TOP, SW_RESTORE,
-                SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
-            };
-            unsafe {
-                let h = hwnd as _;
-                SetWindowPos(h, HWND_TOP, 0, 0, 0, 0,
-                             SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-                if IsIconic(h) != 0 {
-                    ShowWindowAsync(h, SW_RESTORE);
+/// Background event loop. Drains MenuEvent + TrayIconEvent and acts
+/// on them directly via the App Arc / raw Win32 calls. Runs from
+/// `spawn()` until process exit; the process exit kills the thread
+/// (we never explicitly join, mirroring the audio-thread pattern).
+fn event_loop(
+    app: Arc<App>,
+    ctx: egui::Context,
+    ids: TrayIds,
+    hwnd: Arc<AtomicIsize>,
+) {
+    use crossbeam_channel::select;
+    let menu_rx = MenuEvent::receiver();
+    let tray_rx = TrayIconEvent::receiver();
+    loop {
+        select! {
+            recv(menu_rx) -> ev => {
+                match ev {
+                    Ok(MenuEvent { id }) => handle_menu(&id, &app, &ids, &hwnd, &ctx),
+                    Err(_) => return, // channel closed (shouldn't happen)
                 }
-                SetForegroundWindow(h);
+            }
+            recv(tray_rx) -> ev => {
+                match ev {
+                    Ok(TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up,
+                        ..
+                    }) => {
+                        show_window_win32(hwnd.load(Ordering::Relaxed));
+                        ctx.request_repaint();
+                    }
+                    Ok(_) => {} // right/middle clicks, double-click, etc.
+                    Err(_) => return,
+                }
             }
         }
-        ctx.request_repaint();
+    }
+}
+
+fn handle_menu(
+    id: &MenuId,
+    app: &Arc<App>,
+    ids: &TrayIds,
+    hwnd: &AtomicIsize,
+    ctx: &egui::Context,
+) {
+    if *id == ids.trim_25 {
+        app.adjust_latency(25);
+    } else if *id == ids.trim_100 {
+        app.adjust_latency(100);
+    } else if *id == ids.pad_25 {
+        app.adjust_latency(-25);
+    } else if *id == ids.pad_100 {
+        app.adjust_latency(-100);
+    } else if *id == ids.resync {
+        if let Err(e) = app.resync() {
+            warn!("tray resync failed: {}", e);
+        }
+    } else if *id == ids.enable {
+        let new_state = !app.is_streaming_enabled();
+        if let Err(e) = app.set_streaming_enabled(new_state) {
+            warn!("tray toggle failed: {}", e);
+        }
+    } else if *id == ids.switch_speaker || *id == ids.show_window {
+        show_window_win32(hwnd.load(Ordering::Relaxed));
+    } else if *id == ids.open_web {
+        if app.is_web_ui_enabled() {
+            open_web_ui(&app.config.advertise_ip, app.config.bind.port());
+        }
+    } else if *id == ids.quit {
+        info!("tray: quit requested");
+        app.request_shutdown();
+        // Force the window visible so gui.rs::update() runs and
+        // executes its shutdown sequence (drop tray, ViewportCommand
+        // Close). Without this, a hidden window stays hidden and
+        // update() never sees the shutdown flag.
+        show_window_win32(hwnd.load(Ordering::Relaxed));
+    }
+    ctx.request_repaint();
+}
+
+/// Raw Win32 "bring this window to the foreground" sequence.
+/// `SetWindowPos` with `SWP_SHOWWINDOW` flips visibility AND lifts
+/// Z-order in one synchronous call, sidestepping the eframe
+/// ViewportCommand queue (which doesn't drain on hidden windows —
+/// emilk/egui#5229, #3655). `SW_RESTORE` handles the minimised case.
+/// `ShowWindowAsync` is used for `SW_RESTORE` so the call is safe
+/// from a non-owning thread (this fn runs on the tray bg thread).
+fn show_window_win32(hwnd: isize) {
+    if hwnd == 0 {
+        return;
+    }
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        IsIconic, SetForegroundWindow, SetWindowPos, ShowWindowAsync,
+        HWND_TOP, SW_RESTORE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
+    };
+    unsafe {
+        let h = hwnd as _;
+        SetWindowPos(h, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+        if IsIconic(h) != 0 {
+            ShowWindowAsync(h, SW_RESTORE);
+        }
+        SetForegroundWindow(h);
     }
 }
 

--- a/service/src/user_config.rs
+++ b/service/src/user_config.rs
@@ -1,0 +1,69 @@
+//! Persisted user preferences.
+//!
+//! Tiny JSON file at `%APPDATA%\StreamToSpeaker\config.json` that
+//! survives across launches. Currently holds:
+//!   - `last_speaker_id`: the stable id of the speaker the user last
+//!     explicitly selected. Used to auto-reconnect on next launch.
+//!     `None` on first launch (or after the user clicks "Forget
+//!     speaker"), which is what causes the onboarding card to show.
+//!   - `onboarding_dismissed`: whether the user clicked "Got it" on
+//!     the onboarding card. Persisted so we don't re-show it on
+//!     subsequent launches.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct UserConfig {
+    #[serde(default)]
+    pub last_speaker_id: Option<String>,
+    #[serde(default)]
+    pub onboarding_dismissed: bool,
+}
+
+fn config_dir() -> Option<PathBuf> {
+    // %APPDATA% on Windows. On non-Windows (tests, lint runs), fall
+    // back to $XDG_CONFIG_HOME or $HOME/.config; this binary is
+    // gated to Windows in practice but the module compiles cross-
+    // platform so unit-test builds don't need a cfg fence.
+    if let Ok(p) = std::env::var("APPDATA") {
+        Some(PathBuf::from(p).join("StreamToSpeaker"))
+    } else if let Ok(p) = std::env::var("XDG_CONFIG_HOME") {
+        Some(PathBuf::from(p).join("stream-to-speaker"))
+    } else if let Ok(p) = std::env::var("HOME") {
+        Some(PathBuf::from(p).join(".config").join("stream-to-speaker"))
+    } else {
+        None
+    }
+}
+
+fn config_path() -> Option<PathBuf> {
+    config_dir().map(|d| d.join("config.json"))
+}
+
+impl UserConfig {
+    pub fn load() -> Self {
+        let Some(path) = config_path() else { return Self::default(); };
+        let Ok(content) = std::fs::read_to_string(&path) else { return Self::default(); };
+        serde_json::from_str(&content).unwrap_or_default()
+    }
+
+    /// Best-effort save. Logged-on-failure rather than propagated — a
+    /// failed config write should never block UI actions like speaker
+    /// selection.
+    pub fn save(&self) {
+        let Some(path) = config_path() else { return; };
+        let Some(dir) = path.parent() else { return; };
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            log::warn!("user_config: mkdir {}: {}", dir.display(), e);
+            return;
+        }
+        let content = match serde_json::to_string_pretty(self) {
+            Ok(s) => s,
+            Err(e) => { log::warn!("user_config: serialize: {}", e); return; }
+        };
+        if let Err(e) = std::fs::write(&path, content) {
+            log::warn!("user_config: write {}: {}", path.display(), e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This branch fixes the long list of issues the previous installer surfaced — the audio endpoint stuck at "Internal AUX Jack" + disabled, the tray Show-window doing nothing, auto-connected speakers playing silence until Resync, the broken rescan button, and a handful of smaller UX items. Each fix is an isolated commit so any single one can be reverted without losing the rest.

## Driver: endpoint classification

`2600396` … `af05f8a` — the audio side. The endpoint was stuck at the placeholder "Internal AUX Jack" name because **four** things were wrong, all at once:

1. **GUID typo in INF** — `KSNODETYPE_SPEAKER` was defined as `{DFF21BE2-...}` which is actually `KSNODETYPE_DESKTOP_MICROPHONE`. The real speaker GUID is `{DFF21CE1-...}` (one hex digit difference, USB terminal 0x0301 vs 0x0202). Every downstream property that keyed off `PKEY_AudioEndpoint_Association` was operating on a "microphone-associated render endpoint", which confused every default-enable / form-factor decision in AudioEndpointBuilder.
2. **Bridge pin instance counts `1,1,0` instead of `0,0,0`** — per the Audio Filter Graphs docs, "a bridge pin exists implicitly and cannot be instantiated or deleted". AEB scans for bridge pins with count 0; ours looked instantiable and got skipped during the bridge-pin scan. sysvad and simpleaudiosample both use `0,0,0`.
3. **No `KSPROPSETID_Jack` handlers on the topology filter** — `TopologyMiniportFilterDescriptor.AutomationTable` was `NULL`. AEB queries `KSPROPERTY_JACK_DESCRIPTION` + `_2` to populate `JackSubType`; without a response it falls back to defaults that emit the "Internal AUX Jack" name.
4. **`KSJACK_DESCRIPTION` values literally produced "Internal AUX Jack"** — my first cut used `eConnTypeOtherDigital + eGeoLocNotApplicable + eGenLocOther`, which is the exact tuple AEB's name-composition function uses to spell "Internal AUX Jack". Switched to simpleaudiosample's Speakers values (`eConnTypeUnknown + eGeoLocFront + eGenLocPrimaryBox`).

Plus `Include=ks.inf,wdmaudio.inf` + `Needs=KS.Registration, WDMAUDIO.Registration` in the INF (`6ff4c94`) — required by Microsoft's "Installing Core System Components" docs and missing from ours. Without it the MediaCategories friendly-name table isn't seeded under our software key, and the bridge-pin Category GUID can't resolve to "Speakers".

And `JACKDESC_RGB` is not exposed in WDK 10.0.26100 `ksmedia.h`, so the Color field uses the inline literal `0x00B3C98C` (`af05f8a`).

## Driver: version handling

`2600396` (subset) — `<SpecifyDriverDirectiveVersion>true</>` added to the vcxproj. Without it `stampinf` updated the DriverVer date but ignored the `TimeStamp` metadata, so the INF stayed stuck at `1.0.0.1` no matter what we set. Driver version bumped to `1.1.0` (MINOR — new KS property surface).

## Installer + post-install scripts

- `CloseApplications=force` + `AppMutex=Global\StreamToSpeaker.Singleton` so reinstall detects a running service and offers to close it (`2600396`)
- `Pre-Install.ps1` restarts AudioEndpointBuilder + AudioSrv so audiosrv's in-memory cache drops between reinstalls (`aff1c5f`)
- `Rename-Endpoint.ps1` reordered: `SetEndpointVisibility(true)` runs before `SetPropertyValue(FriendlyName)` (Win11 24H2 race), force-sets FormFactor / Association / EnableEndpointByDefault via IPolicyConfig, and matches DeviceDesc anywhere (not just as prefix) so the stale-cache prefix variant gets renamed too (`aff1c5f` + `0b36f91`)
- New `scripts/Diagnose.ps1` — reads the six critical MMDevices PKEYs and prints a decision tree so we can localize any future failures from user-provided output

## GUI / tray

- `cef5cf1` GUI polish from the prior PR carried over (palette, theme toggle, link buttons, clickable() cursor helper, onboarding card structure)
- `2600396` + `aff1c5f` + `110c654` Quit-actually-quits, then hide/show via raw Win32 (after viewport-command attempts failed), then `with_taskbar(false)` removed (winit's `ITaskbarList::DeleteTab` was breaking the show path)
- **`d31bf06`** — the actual fix for Show-window-from-tray. Events now drained on a dedicated bg thread (not `update()`, which doesn't run while the window is hidden — no `WM_PAINT`). `SetWindowPos(SWP_SHOWWINDOW)` + `IsIconic` + `SW_RESTORE` + `SetForegroundWindow` is called directly from the bg thread when the user clicks the tray icon
- **`2986bad`** — audio thread spawn moved before the initial `select_speaker` so the speaker connects to a stream that's already producing data (previously: speaker connected before silence injection started → empty body → Sonos stayed in "connected but not playing" state until manual Resync)
- **`9199a7c`** — `%APPDATA%\StreamToSpeaker\config.json` persists `last_speaker_id` (auto-reconnect after first manual pick, no auto-select on first launch) and `onboarding_dismissed` (onboarding card stays shown until "Got it", regardless of speaker state)
- **`c6b26ff`** — Rescan button wired to a real `App::trigger_rescan` (was rendered but had no `.clicked()` handler)
- **`08bbb4e`** — tray icon redesigned as a chunky body+cone that survives 32→16 px downsampling (the old design collapsed to a green square at tray size)

## Service version

Bumped to `0.2.0` to match the driver's `1.1.0` prefix per CLAUDE.md's semver discipline.

## Test plan

- [x] Fresh install: device appears as "Stream To Speaker" in Sound Settings and is enabled (no "Allow" toggle, no "Internal AUX Jack" prefix)
- [x] First launch: onboarding card visible; manually picking a speaker hides the auto-binding behaviour and persists the choice
- [ ] Subsequent launches: app auto-reconnects to last picked speaker; audio plays immediately (no Resync needed)
- [x] Click "Got it" on onboarding → card stays dismissed across restarts
- [ ] Rescan button: clicking triggers a new SSDP sweep within ~3 s
- [x] Hide-to-tray → click tray icon → window comes back
- [x] Tray → Quit → process actually exits, tray icon disappears
- [ ] Reinstall with the GUI still running: installer prompts to close it
- [x] Tray icon in the systray is a visible speaker shape, not a square
- [ ] If anything's still off, run `{app}\scripts\Diagnose.ps1` as admin and paste the output

---
