### PR TITLE
airplay: add RAOP (AirPlay 1) sender — discovery + RTSP + RTP/UDP audio

### DIFF
--- a/service/Cargo.lock
+++ b/service/Cargo.lock
@@ -25,6 +25,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +225,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +267,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -385,6 +426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +497,16 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clang-sys"
@@ -532,6 +592,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -627,6 +693,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +726,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +757,27 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -927,6 +1033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1071,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1041,6 +1164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1244,16 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1521,6 +1660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1690,16 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -1702,6 +1861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,6 +1918,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1831,6 +2005,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "mio",
+ "socket2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +2055,18 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1982,6 +2181,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,12 +2208,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2436,6 +2672,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,6 +2766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -2613,6 +2879,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2986,27 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -2818,10 +3135,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2949,6 +3298,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,10 +3330,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stream-to-speaker"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
+ "aes",
  "anyhow",
+ "base64",
  "byteorder",
+ "cbc",
  "clap",
  "cpal",
  "crossbeam-channel",
@@ -2973,13 +3344,18 @@ dependencies = [
  "eframe",
  "egui",
  "env_logger",
+ "flume",
  "log",
+ "mdns-sd",
  "percent-encoding",
  "quick-xml 0.36.2",
+ "rand",
  "raw-window-handle",
  "roxmltree",
+ "rsa",
  "serde",
  "serde_json",
+ "sha1",
  "socket2",
  "thiserror 1.0.69",
  "tiny_http",
@@ -2993,6 +3369,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3225,6 +3607,12 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -3965,6 +4353,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-to-speaker"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.74"
 description = "Stream To Speaker — user-mode bridge between a Windows virtual audio driver (or WASAPI loopback) and any UPnP/OpenHome network speaker (Sonos, IKEA StreamToSpeaker, etc)."
@@ -36,6 +36,30 @@ percent-encoding = "2"
 # the obvious fit.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# AirPlay support.
+#
+# mDNS-sd: pure-Rust mDNS browser for `_raop._tcp` / `_airplay._tcp`
+# discovery. Avoids the system Bonjour dep (mDNSResponder is not present
+# on stock Windows, and we don't want to ship the Apple installer).
+mdns-sd = { version = "0.13", default-features = false, features = ["async"] }
+# mdns-sd's receiver is a `flume::Receiver<ServiceEvent>` — pull flume
+# in directly so we can name the error type without leaking the transit
+# crate through mdns-sd's API surface.
+flume = { version = "0.11", default-features = false }
+# RSA-OAEP encryption of the per-session AES key, sent in the SDP
+# `rsaaeskey` attribute. We use the public "Apple AirTunes" RSA key
+# whose private half lives on every RAOP receiver (AirPort Express
+# firmware leak, ~2004). Pure-Rust — no OpenSSL on the Windows build.
+rsa = { version = "0.9", default-features = false, features = ["sha2"] }
+# AES-128-CBC for the audio payload encryption layer.
+aes = { version = "0.8", default-features = false }
+cbc = { version = "0.1", default-features = false, features = ["block-padding"] }
+# Hash for RSA-OAEP MGF1 — RAOP locks this to SHA-1 (legacy).
+sha1 = { version = "0.10", default-features = false }
+# Base64 for SDP attributes + Apple-Challenge response.
+base64 = "0.22"
+# RNG for AES key + IV + RTP SSRC + Apple-Challenge nonces.
+rand = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 # WASAPI loopback fallback. cpal supports WASAPI loopback on Windows.

--- a/service/src/airplay/alac.rs
+++ b/service/src/airplay/alac.rs
@@ -1,0 +1,172 @@
+//! Build "uncompressed-ALAC" frames from 16-bit stereo PCM.
+//!
+//! AirPlay 1 frames its audio as ALAC, but the codec supports a
+//! pass-through escape that lets a sender ship raw PCM samples wrapped
+//! in a stub ALAC bitstream without actually running the compressor.
+//! Every shipping receiver supports this path — it's how iTunes and
+//! every open-source sender (PipeWire `module-raop-sink`, shairport,
+//! node_airtunes, AirConnect, ...) actually send audio.
+//!
+//! The bit layout below is taken verbatim from PipeWire's
+//! `write_codec_pcm()` (its `module-raop-sink.c`) and cross-checked
+//! against the openairplay reference. Each frame is a 55-bit header
+//! followed by interleaved big-endian 16-bit samples and a 3-bit
+//! end-of-element tag, padded out to a whole byte.
+//!
+//! ## Header (55 bits)
+//!
+//! | Bits | Value          | Meaning                                       |
+//! |------|----------------|-----------------------------------------------|
+//! |   3  | `001`          | Element type: CPE (Channel Pair Element, stereo) |
+//! |   4  | `0000`         | Instance tag (always 0)                       |
+//! |   8  | `0x00`         | Header byte: "Unknown" continuation           |
+//! |   4  | `0000`         | More header padding                           |
+//! |   1  | `1`            | `hassize` — frame length follows              |
+//! |   2  | `00`           | Unused                                        |
+//! |   1  | `1`            | `is-not-compressed` — escape: raw PCM follows |
+//! |  32  | `n_frames`     | Frame count, BE u32                           |
+//!
+//! Then `n_frames * 2 * 16` bits of stereo audio (sample order
+//! `L_hi, L_lo, R_hi, R_lo` per source frame), then `0b111` end tag,
+//! then 0..7 bits of zero pad up to a whole byte.
+//!
+//! For our canonical 352-frame stereo packet:
+//!   * Header:       55 bits
+//!   * Audio:    11264 bits  (352 × 2 × 16)
+//!   * End tag:      3 bits
+//!   * Total:    11322 bits = 1415.25 bytes → padded to **1416 bytes**.
+
+/// Build a single ALAC frame containing `frames` stereo sample pairs.
+/// `samples_le` is `[L0, R0, L1, R1, ...]` interleaved i16 in host
+/// (little-endian on Windows) order — we re-emit as big-endian inside
+/// the bitstream.
+///
+/// Returns a fresh `Vec<u8>` of the bit-packed frame, byte-aligned.
+pub fn build_uncompressed_alac_frame(samples_le: &[i16]) -> Vec<u8> {
+    debug_assert!(samples_le.len() % 2 == 0, "stereo frame count must be even");
+    let n_frames = (samples_le.len() / 2) as u32;
+
+    // Pre-size: header(55) + samples(n*32) + end(3), rounded up.
+    let bit_len: u64 = 55 + (n_frames as u64) * 32 + 3;
+    let byte_len = ((bit_len + 7) / 8) as usize;
+    let mut out = vec![0u8; byte_len];
+    let mut bw = BitWriter::new(&mut out);
+
+    // 55-bit fixed header for "stereo, hassize, uncompressed".
+    bw.write_bits(0b001, 3); // CPE
+    bw.write_bits(0, 4); // instance tag
+    bw.write_bits(0, 8); // unknown continuation
+    bw.write_bits(0, 4); // unknown
+    bw.write_bits(1, 1); // hassize
+    bw.write_bits(0, 2); // unused
+    bw.write_bits(1, 1); // is-not-compressed (escape)
+    // 32-bit frame count, BE byte order.
+    bw.write_bits((n_frames >> 24) & 0xff, 8);
+    bw.write_bits((n_frames >> 16) & 0xff, 8);
+    bw.write_bits((n_frames >> 8) & 0xff, 8);
+    bw.write_bits(n_frames & 0xff, 8);
+
+    // PCM samples — big-endian bytes per channel.
+    for &s in samples_le {
+        let be = s.to_be_bytes();
+        bw.write_bits(be[0] as u32, 8);
+        bw.write_bits(be[1] as u32, 8);
+    }
+
+    // End-of-element marker.
+    bw.write_bits(0b111, 3);
+
+    out
+}
+
+/// Minimal MSB-first bit writer over a pre-sized byte buffer. Bits
+/// beyond `buf.len() * 8` are silently dropped (caller is responsible
+/// for sizing correctly).
+struct BitWriter<'a> {
+    buf: &'a mut [u8],
+    bit_pos: usize,
+}
+
+impl<'a> BitWriter<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, bit_pos: 0 }
+    }
+
+    fn write_bits(&mut self, value: u32, num_bits: u32) {
+        debug_assert!(num_bits <= 32);
+        let mut remaining = num_bits;
+        while remaining > 0 {
+            let byte_idx = self.bit_pos / 8;
+            if byte_idx >= self.buf.len() {
+                return;
+            }
+            let bit_offset_in_byte = self.bit_pos % 8;
+            let space_in_byte = 8 - bit_offset_in_byte;
+            let bits_now = remaining.min(space_in_byte as u32);
+
+            let shift = remaining - bits_now;
+            let chunk = ((value >> shift) & ((1u32 << bits_now) - 1)) as u8;
+            let dest_shift = (space_in_byte as u32 - bits_now) as u8;
+            self.buf[byte_idx] |= chunk << dest_shift;
+
+            self.bit_pos += bits_now as usize;
+            remaining -= bits_now;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stereo_352_frame_is_1416_bytes() {
+        // The canonical RAOP frame size — every implementation produces
+        // exactly 1416 bytes for 352 stereo 16-bit samples.
+        let samples = vec![0i16; 352 * 2];
+        let frame = build_uncompressed_alac_frame(&samples);
+        assert_eq!(frame.len(), 1416);
+    }
+
+    #[test]
+    fn empty_frame_has_no_samples_just_header_and_tag() {
+        // 55-bit header + 3-bit end tag = 58 bits = 7.25 bytes → 8 bytes.
+        let frame = build_uncompressed_alac_frame(&[]);
+        assert_eq!(frame.len(), 8);
+        // First byte: top 3 bits = `001` (CPE), next 4 = 0000, then 1 bit
+        // of the 8-bit "unknown" zero block.
+        //   001_0000_0  = 0010_0000 = 0x20
+        assert_eq!(frame[0], 0x20);
+    }
+
+    #[test]
+    fn n_frames_field_is_encoded_big_endian() {
+        // Pass exactly 0x01_02_03_04 frames (16,909,060) — not realistic
+        // but unambiguously verifies the 32-bit field order.
+        //
+        // The header bits before n_frames sum to 23, so n_frames begins
+        // at bit 23. Bit 23 is byte 2's bit-0 (MSB-counted) which is
+        // bit-7 in MSB-first writing. Then it spans bytes 2..6 with the
+        // 8-bit byte values shifted into byte 6's MSB.
+        //
+        // Concretely with n_frames = 0x01020304:
+        //   byte 2 bit 0..6 = previous 7 bits of header (zero pad),
+        //   byte 2 bit 7    = top bit of 0x01 (0)
+        //   byte 3          = next 8 bits = 0x02
+        //   ...
+        // For a robust check, just round-trip the build and read back
+        // the 32-bit field from where we know it ends up.
+        let mut samples = Vec::new();
+        samples.resize(0x10 * 2, 0); // arbitrary, won't be 0x01020304
+        let frame = build_uncompressed_alac_frame(&samples);
+        // The first sample's MSB sits at bit 55; bytes 0..6 contain header
+        // bits 0..55. The n_frames field occupies bits 23..55. Extract:
+        let mut bits = 0u64;
+        for b in &frame[0..7] {
+            bits = (bits << 8) | (*b as u64);
+        }
+        // bits now holds bits 0..56, MSB-first. n_frames is bits 23..55:
+        let n = ((bits >> (56 - 55)) & 0xFFFF_FFFF) as u32;
+        assert_eq!(n, 0x10);
+    }
+}

--- a/service/src/airplay/crypto.rs
+++ b/service/src/airplay/crypto.rs
@@ -50,6 +50,67 @@ pub struct SessionKey {
     pub iv: [u8; 16],
 }
 
+/// Audio-stream encryption mode for one session.
+///
+/// Picked at session start based on the receiver's advertised `et=`
+/// TXT-record list:
+///
+///   * `et=1` (and friends) → [`Cipher::AesRsa`] — the classic AirPlay
+///     1 path: AES-128-CBC payload encryption with a session key
+///     wrapped under Apple's public RSA key. Works with AirPort
+///     Express and shairport-sync.
+///   * `et=0` available     → [`Cipher::None`] — the "no encryption"
+///     path. Receivers advertising this accept ANNOUNCE without
+///     `rsaaeskey`/`aesiv` and audio RTP packets without AES. This
+///     is the path AirPlay 2 receivers (Sonos in AP2 mode, modern
+///     speakers) expose to senders that can't do FairPlay pairing.
+///
+/// We prefer `et=0` when available — it skips a round of RSA per
+/// session and works with the broadest set of modern receivers. If
+/// only `et=1` is on offer we fall back to the encrypted path.
+/// FairPlay-only receivers (`et=3/4/5` only) are unsupported here;
+/// they require HomeKit pairing.
+pub enum Cipher {
+    None,
+    AesRsa(SessionKey),
+}
+
+impl Cipher {
+    /// Choose the best cipher we can speak from a receiver's
+    /// advertised `et=` list. Returns `None` if nothing matches
+    /// (FairPlay-only receivers, etc).
+    pub fn pick_for(encryption_types: &[u8]) -> Option<Self> {
+        // Prefer no-encryption first: simpler, works with the AP2
+        // generation, and matches what every "AirConnect"-style
+        // bridge does. RSA is the legacy fallback for AP1-only
+        // receivers that don't advertise et=0.
+        if encryption_types.contains(&0) {
+            Some(Cipher::None)
+        } else if encryption_types.contains(&1) {
+            Some(Cipher::AesRsa(SessionKey::random()))
+        } else {
+            None
+        }
+    }
+
+    /// Short label for logs.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Cipher::None => "none",
+            Cipher::AesRsa(_) => "aes-rsa",
+        }
+    }
+
+    /// Encrypt one audio packet's payload in place. No-op for
+    /// [`Cipher::None`].
+    pub fn encrypt_payload_in_place(&self, buf: &mut [u8]) {
+        match self {
+            Cipher::None => {}
+            Cipher::AesRsa(key) => encrypt_audio_packet_in_place(buf, key),
+        }
+    }
+}
+
 impl SessionKey {
     /// Roll a fresh random AES key + IV.
     pub fn random() -> Self {

--- a/service/src/airplay/crypto.rs
+++ b/service/src/airplay/crypto.rs
@@ -1,0 +1,198 @@
+//! Crypto helpers for the RAOP audio path.
+//!
+//! Two layers:
+//!   1. **Session-key wrap** — at ANNOUNCE time we generate a random
+//!      128-bit AES key + 128-bit IV, RSA-OAEP-SHA1-encrypt the key
+//!      under Apple's published AirPort Express public RSA key (2048-
+//!      bit), and ship the 256-byte ciphertext in the SDP `rsaaeskey`
+//!      attribute. The receiver has the matching private key baked
+//!      into firmware and decrypts.
+//!   2. **Per-packet AES-128-CBC** — every audio packet's payload is
+//!      encrypted in CBC mode with the session key + IV. CBC means
+//!      only the leading `len & ~15` bytes are encrypted; any trailing
+//!      `len & 15` bytes are sent as plaintext (verified against
+//!      shairport-sync receiver source). The IV is reset to the
+//!      original `aes_iv` at the start of every packet — there is no
+//!      CBC chaining across packets.
+//!
+//! The RSA modulus + exponent are the values from `et=1, vn=3`
+//! advertised by every shipping RAOP receiver. The same values appear
+//! in PipeWire's `module-raop-sink`, openairplay/node_airtunes,
+//! shairport-sync, and dozens of other open-source implementations.
+//! They're not secret — Apple's IP claim was on the private half,
+//! which was extracted from leaked AirPort Express firmware ~2004.
+
+use aes::cipher::{BlockEncryptMut, KeyIvInit};
+use anyhow::{anyhow, Context, Result};
+use base64::Engine;
+use rand::RngCore;
+use rsa::{BigUint, Oaep, RsaPublicKey};
+use sha1::Sha1;
+
+/// Apple AirTunes RSA-2048 public modulus, base64.
+///
+/// Verified across PipeWire `module-raop-sink.c`,
+/// `openairplay/node_airtunes`, and the Airtunes2 spec — three
+/// independent sources that all carry the same 256-byte value below.
+/// Note: an older copy in `LinusU/rust-raop-player` has a 1-char typo
+/// (`EpVviyhnimNV…` vs the canonical `EpVviYnhimNV…`) — we use the
+/// canonical version.
+const APPLE_RSA_MODULUS_B64: &str = "59dE8qLieItsH1WgjrcFRKj6eUWqi+bGLOX1HL3U3GhC/j0Qg90u3sG/1CUtwC5vOYvfDmFI6oSFXi5ELabWJmT2dKHzBJKa3k9ok+8t9ucRqMd6DZHJ2YCCLlDRKSKv6kDqnw4UwPdpOMXziC/AMj3Z/lUVX1G7WSHCAWKf1zNS1eLvqr+boEjXuBOitnZ/bDzPHrTOZz0Dew0uowxf/+sG+NCK3eQJVxqcaJ/vEHKIVd2M+5qL71yJQ+87X6oV3eaYvt3zWZYD6z5vYTcrtij2VZ9Zmni/UAaHqn9JdsBWLUEpVviYnhimNVvYFZeCXg/IdTQ+x4IRdiXNv5hEew==";
+
+/// Apple AirTunes public exponent — the conventional 65537 in base64.
+const APPLE_RSA_EXPONENT_B64: &str = "AQAB";
+
+/// 16-byte AES-128 session key and matching IV. Lives for one RAOP
+/// session and is reused for every audio packet.
+#[derive(Debug, Clone)]
+pub struct SessionKey {
+    pub key: [u8; 16],
+    pub iv: [u8; 16],
+}
+
+impl SessionKey {
+    /// Roll a fresh random AES key + IV.
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+        let mut key = [0u8; 16];
+        let mut iv = [0u8; 16];
+        rng.fill_bytes(&mut key);
+        rng.fill_bytes(&mut iv);
+        Self { key, iv }
+    }
+
+    /// RSA-OAEP-SHA1 encrypt this session's AES key under Apple's
+    /// public RSA key. Output is the raw 256-byte ciphertext (2048-bit
+    /// modulus), ready to be base64-without-padding-encoded for the
+    /// SDP attribute.
+    pub fn rsa_wrapped_key(&self) -> Result<Vec<u8>> {
+        let pubkey = apple_rsa_public_key()?;
+        let padding = Oaep::new::<Sha1>();
+        let mut rng = rand::thread_rng();
+        pubkey
+            .encrypt(&mut rng, padding, &self.key)
+            .map_err(|e| anyhow!("RSA-OAEP encrypting session AES key: {}", e))
+    }
+}
+
+/// Reconstruct the Apple RSA public key from the embedded modulus +
+/// exponent. We rebuild each call rather than cache (single-shot per
+/// session start, well under 1 ms even on Windows).
+fn apple_rsa_public_key() -> Result<RsaPublicKey> {
+    let mod_bytes = base64::engine::general_purpose::STANDARD
+        .decode(APPLE_RSA_MODULUS_B64)
+        .context("decoding Apple RSA modulus base64")?;
+    let exp_bytes = base64::engine::general_purpose::STANDARD
+        .decode(APPLE_RSA_EXPONENT_B64)
+        .context("decoding Apple RSA exponent base64")?;
+    let n = BigUint::from_bytes_be(&mod_bytes);
+    let e = BigUint::from_bytes_be(&exp_bytes);
+    RsaPublicKey::new(n, e).map_err(|e| anyhow!("constructing Apple RSA public key: {}", e))
+}
+
+/// Encrypt one audio packet's payload in-place with AES-128-CBC.
+///
+/// **Only the leading `len & !15` bytes — the part that's a whole
+/// number of 16-byte blocks — are encrypted.** Any trailing `len &
+/// 15` bytes are left as plaintext. This matches the RAOP convention
+/// as implemented by every receiver (see shairport-sync's
+/// `openssl_aes_decrypt_cbc` callsite).
+///
+/// The IV is the per-session IV (i.e. CBC does not chain across
+/// packets — each packet is encrypted with the same starting IV).
+pub fn encrypt_audio_packet_in_place(buf: &mut [u8], key: &SessionKey) {
+    type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
+    let blocks = buf.len() / 16;
+    if blocks == 0 {
+        return;
+    }
+    let mut enc = Aes128CbcEnc::new(&key.key.into(), &key.iv.into());
+    // Encrypt block-by-block in-place. We can't use encrypt_padded_mut
+    // because that always adds a padding scheme — RAOP wants raw
+    // block-aligned CBC with no padding and no trailing rewrite.
+    for chunk in buf[..blocks * 16].chunks_exact_mut(16) {
+        let block = aes::cipher::generic_array::GenericArray::from_mut_slice(chunk);
+        enc.encrypt_block_mut(block);
+    }
+}
+
+/// Generate a random 16-byte challenge for the RTSP OPTIONS
+/// Apple-Challenge header. We don't currently verify the receiver's
+/// Apple-Response (it'd need a per-receiver key for verification);
+/// just sending the challenge is what makes receivers consider us a
+/// well-behaved client.
+pub fn random_apple_challenge() -> [u8; 16] {
+    let mut rng = rand::thread_rng();
+    let mut nonce = [0u8; 16];
+    rng.fill_bytes(&mut nonce);
+    nonce
+}
+
+/// Base64-encode without trailing padding — the RAOP convention for
+/// SDP attributes (`rsaaeskey`, `aesiv`) and the Apple-Challenge
+/// header value.
+pub fn base64_nopad(input: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD_NO_PAD.encode(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apple_rsa_key_parses_and_is_2048_bit() {
+        use rsa::traits::PublicKeyParts;
+        let pk = apple_rsa_public_key().expect("Apple RSA public key parses");
+        // 2048 bits / 8 = 256 bytes
+        assert_eq!(pk.size(), 256, "expected 2048-bit modulus");
+    }
+
+    #[test]
+    fn rsa_wrap_produces_256_byte_ciphertext() {
+        let sk = SessionKey::random();
+        let wrapped = sk.rsa_wrapped_key().expect("wrap");
+        assert_eq!(wrapped.len(), 256, "2048-bit RSA → 256-byte ciphertext");
+    }
+
+    #[test]
+    fn cbc_encrypts_only_aligned_prefix_leaves_tail_plaintext() {
+        let sk = SessionKey {
+            key: [0xAA; 16],
+            iv: [0x55; 16],
+        };
+        // 35 bytes = two whole blocks (32) + 3 trailing plaintext bytes.
+        let mut buf = vec![0u8; 35];
+        for (i, b) in buf.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        let trail = buf[32..].to_vec();
+        encrypt_audio_packet_in_place(&mut buf, &sk);
+        // The trailing 3 bytes must be unchanged.
+        assert_eq!(&buf[32..], &trail[..]);
+        // The first 32 bytes must NOT be 0..32 anymore.
+        let pre: Vec<u8> = (0..32u8).collect();
+        assert_ne!(&buf[..32], &pre[..]);
+    }
+
+    #[test]
+    fn cbc_resets_iv_per_call() {
+        // Same input + same key + same starting IV ⇒ same output.
+        // Confirms we're not carrying CBC state between calls.
+        let sk = SessionKey {
+            key: [1; 16],
+            iv: [2; 16],
+        };
+        let payload = vec![0xABu8; 32];
+        let mut a = payload.clone();
+        let mut b = payload.clone();
+        encrypt_audio_packet_in_place(&mut a, &sk);
+        encrypt_audio_packet_in_place(&mut b, &sk);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn base64_nopad_drops_padding() {
+        assert_eq!(base64_nopad(&[1, 2]), "AQI");
+        assert_eq!(base64_nopad(&[1, 2, 3]), "AQID");
+    }
+}

--- a/service/src/airplay/discovery.rs
+++ b/service/src/airplay/discovery.rs
@@ -1,0 +1,301 @@
+//! mDNS-based discovery of `_raop._tcp.local.` services.
+//!
+//! Modelled on `ssdp.rs` so the GUI can treat AirPlay and UPnP
+//! discoveries symmetrically: both produce a shared list of speakers,
+//! both expose `find_by_id` / `replace`, both run a background thread
+//! that keeps the list fresh.
+//!
+//! ## RAOP TXT record fields
+//!
+//! Per the unofficial AirPlay specification, the keys we care about are:
+//!
+//! | Key | Meaning                                              |
+//! |-----|------------------------------------------------------|
+//! | `txtvers` | TXT record version (always 1)                  |
+//! | `ch`      | Channel count (we want 2)                      |
+//! | `sr`      | Sample rate (we want 44100)                    |
+//! | `ss`      | Sample size in bits (we want 16)               |
+//! | `tp`      | Transport: `UDP` / `TCP`                       |
+//! | `cn`      | Comma-separated codecs: 0=PCM 1=ALAC 2=AAC ... |
+//! | `et`      | Comma-separated encryption types: 0=none 1=RSA |
+//! | `vn`      | RSA version (3 = the published Apple key)      |
+//! | `md`      | Metadata types supported (we don't send any)   |
+//! | `pw`      | Password protected (we don't support this yet) |
+//! | `am`      | Apple model — purely informational             |
+//!
+//! The mDNS *service name* is conventionally `<MAC>@<FriendlyName>`,
+//! e.g. `B8E93735AC11@Living Room`. We split on `@` to get the user-
+//! facing name; the MAC is the receiver's stable identifier and is what
+//! we use for our `stable_id`.
+
+use anyhow::Result;
+use log::{debug, info, warn};
+use mdns_sd::{ServiceDaemon, ServiceEvent, TxtProperties};
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+/// Service type for AirPlay 1 audio receivers.
+pub const RAOP_SERVICE: &str = "_raop._tcp.local.";
+
+/// One resolved AirPlay receiver.
+#[derive(Debug, Clone)]
+pub struct AirPlayRenderer {
+    /// Friendly name (the part after `@` in the mDNS service name).
+    pub friendly_name: String,
+    /// Stable ID — the MAC address portion of the service name. We use
+    /// the original case-folded form so the ID survives device renames.
+    pub mac_id: String,
+    /// IPv4 of the receiver (we prefer v4 over v6 for socket simplicity).
+    pub ip: IpAddr,
+    /// RTSP control port (defaults to 5000 historically, but discovery
+    /// is authoritative).
+    pub port: u16,
+    /// Encryption types the receiver advertises (from `et=`).
+    pub encryption_types: Vec<u8>,
+    /// Codec ids the receiver advertises (from `cn=`).
+    pub codecs: Vec<u8>,
+    /// Whether `pw=true` was set. We refuse to connect to password-
+    /// protected receivers — implementing RAOP password auth is a
+    /// secondary priority.
+    pub password_protected: bool,
+    /// Raw `am=` model string, surfaced in logs / tooltips.
+    pub model: Option<String>,
+}
+
+impl AirPlayRenderer {
+    /// Stable identifier used by the UI / persistence layer. Prefixed
+    /// so it can't collide with the UPnP `Renderer::stable_id()` (which
+    /// is either a UDN like `uuid:RINCON-…` or an IP literal). The MAC
+    /// is the right anchor — IP can change with DHCP, name with user
+    /// renames.
+    pub fn stable_id(&self) -> String {
+        format!("airplay:{}", self.mac_id)
+    }
+
+    /// True if this receiver supports a path we know how to talk to.
+    /// We require ALAC (cn=1) — every AirPlay receiver supports it —
+    /// and RSA encryption (et=1), again universal. PCM (cn=0) +
+    /// no-encryption (et=0) would be simpler but isn't actually the
+    /// common configuration in the wild despite being in the spec.
+    pub fn is_supported(&self) -> bool {
+        if self.password_protected {
+            return false;
+        }
+        self.codecs.contains(&1) && self.encryption_types.contains(&1)
+    }
+}
+
+/// Shared discovery state. Mirrors `ssdp::DiscoveryState` semantics.
+#[derive(Default)]
+pub struct AirPlayDiscoveryState {
+    inner: Mutex<HashMap<String, AirPlayRenderer>>,
+}
+
+impl AirPlayDiscoveryState {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Snapshot of currently-known receivers, sorted by friendly name.
+    pub fn renderers(&self) -> Vec<AirPlayRenderer> {
+        let map = self.inner.lock().unwrap();
+        let mut v: Vec<AirPlayRenderer> = map.values().cloned().collect();
+        v.sort_by(|a, b| a.friendly_name.cmp(&b.friendly_name));
+        v
+    }
+
+    /// Replace the entire renderer set. Used by the discovery thread
+    /// when an mDNS browse completes a full round.
+    pub fn replace_all(&self, renderers: Vec<AirPlayRenderer>) {
+        let mut map = self.inner.lock().unwrap();
+        map.clear();
+        for r in renderers {
+            map.insert(r.mac_id.clone(), r);
+        }
+    }
+
+    /// Add or update one renderer (called when mDNS resolves a single
+    /// service in the streaming-style event loop).
+    pub fn upsert(&self, renderer: AirPlayRenderer) {
+        let mut map = self.inner.lock().unwrap();
+        map.insert(renderer.mac_id.clone(), renderer);
+    }
+
+    /// Remove by MAC id (mDNS `ServiceRemoved` event).
+    pub fn remove(&self, mac_id: &str) {
+        let mut map = self.inner.lock().unwrap();
+        map.remove(mac_id);
+    }
+
+    /// Find by our public `stable_id()` (i.e. with the `airplay:` prefix).
+    pub fn find_by_id(&self, id: &str) -> Option<AirPlayRenderer> {
+        let mac = id.strip_prefix("airplay:")?;
+        self.inner.lock().unwrap().get(mac).cloned()
+    }
+}
+
+/// Spawn the long-running mDNS browser. The daemon thread is owned by
+/// the `mdns-sd` crate; we keep a single event-consumer thread that
+/// upserts records into `state` as they resolve.
+///
+/// `iface_hint` is informational only — `mdns-sd` listens on all
+/// interfaces by default, and the daemon picks the right one for each
+/// outgoing query based on the receiver's source address. We log the
+/// hint for parity with the SSDP path but don't bind to it.
+pub fn spawn_airplay_discovery(
+    state: Arc<AirPlayDiscoveryState>,
+    iface_hint: Option<Ipv4Addr>,
+) -> Result<()> {
+    let daemon =
+        ServiceDaemon::new().map_err(|e| anyhow::anyhow!("mdns daemon init: {}", e))?;
+    let receiver = daemon
+        .browse(RAOP_SERVICE)
+        .map_err(|e| anyhow::anyhow!("mdns browse {}: {}", RAOP_SERVICE, e))?;
+
+    info!(
+        "AirPlay (RAOP) discovery: browsing {} (iface hint {:?})",
+        RAOP_SERVICE, iface_hint,
+    );
+
+    thread::Builder::new()
+        .name("stream-to-speaker-airplay-mdns".to_string())
+        .spawn(move || {
+            // Hold on to the daemon so it isn't dropped (which would
+            // tear down the background thread it owns).
+            let _daemon_keepalive = daemon;
+            loop {
+                match receiver.recv_timeout(Duration::from_secs(60)) {
+                    Ok(ServiceEvent::ServiceResolved(info)) => {
+                        match build_renderer_from_resolution(&info) {
+                            Some(r) => {
+                                debug!(
+                                    "AirPlay resolved: {} @ {}:{} (mac={}, supported={})",
+                                    r.friendly_name,
+                                    r.ip,
+                                    r.port,
+                                    r.mac_id,
+                                    r.is_supported(),
+                                );
+                                state.upsert(r);
+                            }
+                            None => {
+                                debug!(
+                                    "AirPlay resolved {} but couldn't build renderer (no IPv4?)",
+                                    info.get_fullname()
+                                );
+                            }
+                        }
+                    }
+                    Ok(ServiceEvent::ServiceRemoved(_, fullname)) => {
+                        if let Some(mac) = mac_from_fullname(&fullname) {
+                            debug!("AirPlay removed: {}", fullname);
+                            state.remove(&mac);
+                        }
+                    }
+                    Ok(_) => { /* SearchStarted / ServiceFound / etc. */ }
+                    Err(flume::RecvTimeoutError::Timeout) => {
+                        // No traffic in a minute; loop and keep listening.
+                    }
+                    Err(flume::RecvTimeoutError::Disconnected) => {
+                        warn!("AirPlay mDNS daemon disconnected; discovery stops");
+                        return;
+                    }
+                }
+            }
+        })?;
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Build an [`AirPlayRenderer`] from a resolved mDNS service. Returns
+/// None if the service has no usable IPv4 address.
+fn build_renderer_from_resolution(info: &mdns_sd::ServiceInfo) -> Option<AirPlayRenderer> {
+    let fullname = info.get_fullname();
+
+    // Service name layout: "<MAC>@<FriendlyName>._raop._tcp.local."
+    let (mac_id, friendly_name) = split_service_name(fullname)?;
+
+    let v4_addrs: Vec<IpAddr> = info
+        .get_addresses()
+        .iter()
+        .filter_map(|a| match a {
+            IpAddr::V4(v4) => Some(IpAddr::V4(*v4)),
+            _ => None,
+        })
+        .collect();
+    let ip = match v4_addrs.first().copied() {
+        Some(v) => v,
+        None => return None,
+    };
+
+    let port = info.get_port();
+    let txt = info.get_properties();
+
+    let password_protected = read_txt_bool(txt, "pw");
+    let encryption_types = read_txt_int_list(txt, "et");
+    let codecs = read_txt_int_list(txt, "cn");
+    let model = read_txt_string(txt, "am");
+
+    Some(AirPlayRenderer {
+        friendly_name,
+        mac_id,
+        ip,
+        port,
+        encryption_types,
+        codecs,
+        password_protected,
+        model,
+    })
+}
+
+fn split_service_name(fullname: &str) -> Option<(String, String)> {
+    // Strip the service-type suffix.
+    let trimmed = fullname
+        .strip_suffix(&format!(".{}", RAOP_SERVICE))
+        .or_else(|| fullname.strip_suffix(RAOP_SERVICE))
+        .unwrap_or(fullname);
+    let (mac, friendly) = trimmed.split_once('@')?;
+    let mac = mac.trim().to_string();
+    let friendly = friendly.trim().to_string();
+    if mac.is_empty() || friendly.is_empty() {
+        return None;
+    }
+    Some((mac, friendly))
+}
+
+fn mac_from_fullname(fullname: &str) -> Option<String> {
+    Some(split_service_name(fullname)?.0)
+}
+
+fn read_txt_string(txt: &TxtProperties, key: &str) -> Option<String> {
+    txt.get_property_val_str(key).map(|s| s.to_string())
+}
+
+fn read_txt_bool(txt: &TxtProperties, key: &str) -> bool {
+    match read_txt_string(txt, key) {
+        Some(s) => {
+            let s = s.to_ascii_lowercase();
+            s == "true" || s == "1" || s == "yes"
+        }
+        None => false,
+    }
+}
+
+/// Parse a TXT field whose value is a comma-separated integer list
+/// (`cn=0,1,3` → `[0, 1, 3]`). Returns an empty vec on absence.
+fn read_txt_int_list(txt: &TxtProperties, key: &str) -> Vec<u8> {
+    match read_txt_string(txt, key) {
+        Some(s) => s
+            .split(',')
+            .filter_map(|p| p.trim().parse::<u8>().ok())
+            .collect(),
+        None => Vec::new(),
+    }
+}

--- a/service/src/airplay/discovery.rs
+++ b/service/src/airplay/discovery.rs
@@ -76,15 +76,22 @@ impl AirPlayRenderer {
     }
 
     /// True if this receiver supports a path we know how to talk to.
-    /// We require ALAC (cn=1) — every AirPlay receiver supports it —
-    /// and RSA encryption (et=1), again universal. PCM (cn=0) +
-    /// no-encryption (et=0) would be simpler but isn't actually the
-    /// common configuration in the wild despite being in the spec.
+    ///
+    /// We require:
+    ///   * Not password-protected (we don't speak HTTP-Digest yet).
+    ///   * ALAC (`cn=1`) advertised — universal across AirPlay
+    ///     receivers, but a handful of weird devices only do PCM.
+    ///   * Either no-encryption (`et=0`) OR Apple RSA (`et=1`)
+    ///     advertised. FairPlay-only receivers (`et=3/4/5` exclusive,
+    ///     no `et=0`) require HomeKit pairing and are out of scope.
     pub fn is_supported(&self) -> bool {
         if self.password_protected {
             return false;
         }
-        self.codecs.contains(&1) && self.encryption_types.contains(&1)
+        if !self.codecs.contains(&1) {
+            return false;
+        }
+        self.encryption_types.contains(&0) || self.encryption_types.contains(&1)
     }
 }
 

--- a/service/src/airplay/mod.rs
+++ b/service/src/airplay/mod.rs
@@ -1,0 +1,43 @@
+//! AirPlay 1 / RAOP (Remote Audio Output Protocol) sender.
+//!
+//! Companion to the UPnP path (`upnp.rs` + `ssdp.rs`). Where UPnP relies
+//! on the speaker to pull a WAV stream from our HTTP server, AirPlay is
+//! a push protocol: we open an RTSP control connection, encrypt audio
+//! per-session with AES-128-CBC (key wrapped under Apple's well-known
+//! RSA public key), and push RTP/UDP packets of ALAC-framed PCM at the
+//! receiver.
+//!
+//! ## Scope
+//!
+//! This is **AirPlay 1**, not 2. AP1 covers every shipping speaker that
+//! advertises `_raop._tcp` mDNS — AirPort Express (all generations),
+//! Sonos (all current models in their AirPlay 2 mode fall back to AP1
+//! for senders that don't pair), Shairport-sync receivers, and the long
+//! tail of 3rd-party receivers. It explicitly does **not** cover:
+//!
+//!   * HomePod / HomePod mini — those require AirPlay 2 with HomeKit
+//!     pairing and a working FairPlay handshake. Tracked as future work.
+//!   * AirPlay 2 multi-room — single device per session here.
+//!
+//! ## Modules
+//!
+//! * [`discovery`] — mDNS browse for `_raop._tcp.local.`, building
+//!   [`AirPlayRenderer`] records the user can pick from.
+//! * [`rtsp`] — RTSP/1.0 client implementing the OPTIONS → ANNOUNCE →
+//!   SETUP → RECORD → (audio in parallel) → TEARDOWN flow.
+//! * [`rtp`] — RTP packetizer + audio sender thread.
+//! * [`alac`] — Builds uncompressed ALAC frames from 16-bit stereo PCM.
+//! * [`crypto`] — RSA-wrapped AES-128 session key + per-packet AES-CBC.
+//! * [`session`] — High-level session lifecycle, mirroring
+//!   `app::start_session` / `app::stop_session` for the UPnP path.
+
+pub mod alac;
+pub mod crypto;
+pub mod discovery;
+pub mod rtp;
+pub mod rtsp;
+pub mod session;
+pub mod timing;
+
+pub use discovery::{spawn_airplay_discovery, AirPlayDiscoveryState, AirPlayRenderer};
+pub use session::{AirPlaySession, AirPlaySessionConfig};

--- a/service/src/airplay/rtp.rs
+++ b/service/src/airplay/rtp.rs
@@ -1,0 +1,303 @@
+//! RTP audio packetizer + sender thread.
+//!
+//! Per the RAOP convention every audio packet carries exactly 352
+//! stereo sample frames (the `frame_length` advertised in the ANNOUNCE
+//! SDP). The driver source delivers 10 ms packets (= 441 frames at 44.1
+//! kHz), so we re-frame: accumulate samples in a ring, slice into 352-
+//! frame chunks, build an ALAC frame, encrypt, and send.
+//!
+//! Audio scheduling is paced to wall-clock: each packet is 352 / 44100
+//! ≈ 7.98 ms of audio, so we sleep until the cumulative deadline before
+//! sending. This keeps the receiver's jitter buffer from over- or under-
+//! flowing as long as the source produces audio at real time (which the
+//! upstream silence injector guarantees even during idle).
+//!
+//! ## RTP packet layout
+//!
+//! ```text
+//!  0                   1                   2                   3
+//!  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |V=2|P|X| CC=0  |M|     PT=96     |       sequence number         |
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |                           timestamp                           |
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |                             SSRC                              |
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |                  encrypted ALAC frame ...
+//! ```
+//!
+//! Marker bit (M) is set on the very first audio packet of a session;
+//! 0 thereafter. We deliberately do NOT set it on the per-resync first
+//! packet — RAOP receivers treat M=1 as a "this is the start of a
+//! brand-new stream" flush, which would re-introduce the prebuffer
+//! latency.
+
+use anyhow::{Context, Result};
+use byteorder::{BigEndian, ByteOrder};
+use crossbeam_channel::{Receiver, TryRecvError};
+use log::{debug, info, warn};
+use rand::Rng;
+use std::net::{IpAddr, SocketAddr, UdpSocket};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::airplay::alac::build_uncompressed_alac_frame;
+use crate::airplay::crypto::{encrypt_audio_packet_in_place, SessionKey};
+use crate::http_server::PcmFrame;
+use crate::WIRE_SAMPLE_RATE;
+
+/// Sample frames per RTP packet — matches the ANNOUNCE `fmtp` value.
+pub const FRAMES_PER_PACKET: usize = 352;
+
+/// RTP payload type. RAOP fixes this at 96 (dynamic, first in range).
+const RTP_PT_AUDIO: u8 = 0x60;
+
+/// RTP version 2 in the top two bits of byte 0.
+const RTP_V2: u8 = 0x80;
+
+/// Bytes per stereo sample frame in our wire format (16-bit L + R).
+const BYTES_PER_FRAME: usize = 4;
+
+/// Initial RTP sequence number — we pick a random 16-bit value at
+/// session start so successive sessions don't collide in any receiver-
+/// side sequence-tracking state.
+pub fn random_initial_seq() -> u16 {
+    rand::thread_rng().gen()
+}
+
+/// Initial RTP timestamp — random 32-bit per RFC 3550 recommendation.
+pub fn random_initial_rtptime() -> u32 {
+    rand::thread_rng().gen()
+}
+
+/// Random SSRC for the session.
+pub fn random_ssrc() -> u32 {
+    rand::thread_rng().gen()
+}
+
+/// Configuration passed into the audio sender thread.
+pub struct RtpSenderConfig {
+    /// Local UDP socket to send audio from. Bound by the session
+    /// before the thread starts so its local port can be reported in
+    /// SETUP.
+    pub audio_socket: UdpSocket,
+    /// Receiver IP + port — destination for the audio stream (from
+    /// the SETUP response's `server_port=`).
+    pub receiver_addr: SocketAddr,
+    /// Session AES key + IV.
+    pub session_key: SessionKey,
+    /// Initial RTP sequence number (echoed in the RECORD `RTP-Info`
+    /// header, so must match what the session declared).
+    pub initial_seq: u16,
+    /// Initial RTP timestamp.
+    pub initial_rtptime: u32,
+    /// SSRC.
+    pub ssrc: u32,
+    /// PCM source — a subscription to `StreamHub`. PcmFrame.0 holds
+    /// little-endian i16 samples, interleaved L,R,L,R,...
+    pub samples_rx: Receiver<PcmFrame>,
+    /// Stop signal — when true, the thread drains its pending audio
+    /// and exits.
+    pub stop_flag: Arc<AtomicBool>,
+    /// Friendly receiver name, for log lines.
+    pub receiver_name: String,
+    /// Shared "current RTP timestamp" the sync packet sender reads off
+    /// once per second so it can anchor its `RTP - latency` value to
+    /// the same clock we're advancing here.
+    pub current_rtptime: Arc<AtomicU32>,
+}
+
+/// Spawn the audio sender thread. Returns once the thread is running.
+/// The thread terminates when `stop_flag` is set OR when the PCM channel
+/// disconnects (which happens when the StreamHub drops the subscription).
+pub fn spawn_audio_sender(cfg: RtpSenderConfig) -> Result<std::thread::JoinHandle<()>> {
+    let name = format!("stream-to-speaker-airplay-rtp:{}", cfg.receiver_name);
+    let handle = std::thread::Builder::new()
+        .name(name)
+        .spawn(move || run_sender(cfg))
+        .context("spawning AirPlay audio sender")?;
+    Ok(handle)
+}
+
+fn run_sender(cfg: RtpSenderConfig) {
+    info!(
+        "AirPlay RTP sender starting → {} (initial seq={}, rtptime={})",
+        cfg.receiver_addr, cfg.initial_seq, cfg.initial_rtptime,
+    );
+
+    let mut seq = cfg.initial_seq;
+    let mut rtptime = cfg.initial_rtptime;
+    let mut packet_count: u64 = 0;
+    let mut sample_ring: Vec<i16> = Vec::with_capacity(FRAMES_PER_PACKET * BYTES_PER_FRAME);
+
+    let start = Instant::now();
+    let packet_duration = Duration::from_nanos(
+        ((FRAMES_PER_PACKET as u64) * 1_000_000_000) / (WIRE_SAMPLE_RATE as u64),
+    );
+
+    loop {
+        if cfg.stop_flag.load(Ordering::Acquire) {
+            debug!("AirPlay RTP sender: stop flag set, exiting");
+            break;
+        }
+
+        // Pull all currently-available frames into the ring. Block
+        // briefly for the first frame to keep the loop from spinning
+        // while we wait for the producer.
+        let blocking_timeout = Duration::from_millis(50);
+        match cfg.samples_rx.recv_timeout(blocking_timeout) {
+            Ok(frame) => {
+                append_samples_from_frame(&mut sample_ring, &frame);
+                // Drain anything else queued without blocking.
+                loop {
+                    match cfg.samples_rx.try_recv() {
+                        Ok(f) => append_samples_from_frame(&mut sample_ring, &f),
+                        Err(TryRecvError::Empty) => break,
+                        Err(TryRecvError::Disconnected) => {
+                            info!("AirPlay RTP sender: PCM source disconnected, exiting");
+                            return;
+                        }
+                    }
+                }
+            }
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                // No fresh audio. Don't burn CPU; loop again.
+                continue;
+            }
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
+                info!("AirPlay RTP sender: PCM source disconnected, exiting");
+                return;
+            }
+        }
+
+        // Slice 352-frame packets out of the ring while we have enough.
+        let mut packets_this_round = 0u32;
+        while sample_ring.len() >= FRAMES_PER_PACKET * 2 {
+            let pkt_samples: Vec<i16> = sample_ring
+                .drain(..FRAMES_PER_PACKET * 2)
+                .collect();
+            let alac_frame = build_uncompressed_alac_frame(&pkt_samples);
+            let pkt_bytes = build_rtp_packet(
+                seq,
+                rtptime,
+                cfg.ssrc,
+                packet_count == 0,
+                &alac_frame,
+                &cfg.session_key,
+            );
+
+            // Pace to wall-clock so we don't outrun the receiver's
+            // jitter buffer. We compute the absolute deadline from
+            // packet_count so accumulated jitter doesn't drift.
+            let deadline =
+                start + packet_duration.saturating_mul((packet_count + 1) as u32);
+            let now = Instant::now();
+            if deadline > now {
+                std::thread::sleep(deadline - now);
+            }
+
+            if let Err(e) = cfg.audio_socket.send_to(&pkt_bytes, cfg.receiver_addr) {
+                warn!("AirPlay RTP send failed: {}", e);
+                // Receiver disappeared — give up; the session manager
+                // will notice via TCP keepalive and tear down.
+                return;
+            }
+
+            seq = seq.wrapping_add(1);
+            rtptime = rtptime.wrapping_add(FRAMES_PER_PACKET as u32);
+            cfg.current_rtptime.store(rtptime, Ordering::Release);
+            packet_count += 1;
+            packets_this_round += 1;
+            if packets_this_round > 32 {
+                // Avoid starving the inbound channel reader.
+                break;
+            }
+        }
+    }
+
+    info!(
+        "AirPlay RTP sender stopped after {} packets ({} s of audio)",
+        packet_count,
+        packet_count * (FRAMES_PER_PACKET as u64) / (WIRE_SAMPLE_RATE as u64),
+    );
+}
+
+/// Re-interpret the LE-byte PcmFrame buffer as i16 samples and append
+/// them to the ring. Source format is L0_lo, L0_hi, R0_lo, R0_hi, ...
+fn append_samples_from_frame(ring: &mut Vec<i16>, frame: &PcmFrame) {
+    let bytes = &**frame.0;
+    let n_samples = bytes.len() / 2;
+    let start = ring.len();
+    ring.resize(start + n_samples, 0);
+    for i in 0..n_samples {
+        let lo = bytes[i * 2];
+        let hi = bytes[i * 2 + 1];
+        ring[start + i] = i16::from_le_bytes([lo, hi]);
+    }
+}
+
+/// Build a complete RTP packet: 12-byte header + AES-encrypted payload.
+fn build_rtp_packet(
+    seq: u16,
+    timestamp: u32,
+    ssrc: u32,
+    is_first_packet: bool,
+    alac_frame: &[u8],
+    session_key: &SessionKey,
+) -> Vec<u8> {
+    let mut pkt = vec![0u8; 12 + alac_frame.len()];
+
+    pkt[0] = RTP_V2;
+    let marker = if is_first_packet { 0x80 } else { 0x00 };
+    pkt[1] = marker | RTP_PT_AUDIO;
+    BigEndian::write_u16(&mut pkt[2..4], seq);
+    BigEndian::write_u32(&mut pkt[4..8], timestamp);
+    BigEndian::write_u32(&mut pkt[8..12], ssrc);
+
+    pkt[12..].copy_from_slice(alac_frame);
+    encrypt_audio_packet_in_place(&mut pkt[12..], session_key);
+    pkt
+}
+
+/// Bind a single UDP socket to the same local IP we'll advertise in
+/// SDP. Lets the OS pick the port. Used for the audio, control, and
+/// timing sockets — each session needs three.
+pub fn bind_udp(local_ip: IpAddr) -> Result<UdpSocket> {
+    let sock = UdpSocket::bind(SocketAddr::new(local_ip, 0))
+        .with_context(|| format!("bind UDP on {}", local_ip))?;
+    sock.set_nonblocking(false)?;
+    Ok(sock)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rtp_header_layout() {
+        let sk = SessionKey {
+            key: [0; 16],
+            iv: [0; 16],
+        };
+        // Empty ALAC frame so we can inspect the header byte-by-byte.
+        let pkt = build_rtp_packet(0x1234, 0xABCD_0123, 0xDEAD_BEEF, true, &[], &sk);
+        assert_eq!(pkt.len(), 12);
+        assert_eq!(pkt[0], 0x80); // V=2 P=0 X=0 CC=0
+        assert_eq!(pkt[1], 0x80 | 0x60); // marker + PT=96
+        assert_eq!(&pkt[2..4], &[0x12, 0x34]);
+        assert_eq!(&pkt[4..8], &[0xAB, 0xCD, 0x01, 0x23]);
+        assert_eq!(&pkt[8..12], &[0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn rtp_subsequent_packets_have_no_marker() {
+        let sk = SessionKey {
+            key: [0; 16],
+            iv: [0; 16],
+        };
+        let pkt = build_rtp_packet(0, 0, 0, false, &[], &sk);
+        assert_eq!(pkt[1], 0x60); // PT=96, no marker
+    }
+}

--- a/service/src/airplay/rtp.rs
+++ b/service/src/airplay/rtp.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::airplay::alac::build_uncompressed_alac_frame;
-use crate::airplay::crypto::{encrypt_audio_packet_in_place, SessionKey};
+use crate::airplay::crypto::Cipher;
 use crate::http_server::PcmFrame;
 use crate::WIRE_SAMPLE_RATE;
 
@@ -86,8 +86,11 @@ pub struct RtpSenderConfig {
     /// Receiver IP + port — destination for the audio stream (from
     /// the SETUP response's `server_port=`).
     pub receiver_addr: SocketAddr,
-    /// Session AES key + IV.
-    pub session_key: SessionKey,
+    /// Per-session cipher — either AES-RSA or no-op for receivers
+    /// that advertise `et=0`. Shared with the packet builder by Arc
+    /// so we don't clone the (potentially large) SessionKey buffer
+    /// every packet.
+    pub cipher: Arc<Cipher>,
     /// Initial RTP sequence number (echoed in the RECORD `RTP-Info`
     /// header, so must match what the session declared).
     pub initial_seq: u16,
@@ -185,7 +188,7 @@ fn run_sender(cfg: RtpSenderConfig) {
                 cfg.ssrc,
                 packet_count == 0,
                 &alac_frame,
-                &cfg.session_key,
+                &cfg.cipher,
             );
 
             // Pace to wall-clock so we don't outrun the receiver's
@@ -238,14 +241,14 @@ fn append_samples_from_frame(ring: &mut Vec<i16>, frame: &PcmFrame) {
     }
 }
 
-/// Build a complete RTP packet: 12-byte header + AES-encrypted payload.
+/// Build a complete RTP packet: 12-byte header + (optionally encrypted) payload.
 fn build_rtp_packet(
     seq: u16,
     timestamp: u32,
     ssrc: u32,
     is_first_packet: bool,
     alac_frame: &[u8],
-    session_key: &SessionKey,
+    cipher: &Cipher,
 ) -> Vec<u8> {
     let mut pkt = vec![0u8; 12 + alac_frame.len()];
 
@@ -257,7 +260,7 @@ fn build_rtp_packet(
     BigEndian::write_u32(&mut pkt[8..12], ssrc);
 
     pkt[12..].copy_from_slice(alac_frame);
-    encrypt_audio_packet_in_place(&mut pkt[12..], session_key);
+    cipher.encrypt_payload_in_place(&mut pkt[12..]);
     pkt
 }
 
@@ -277,12 +280,9 @@ mod tests {
 
     #[test]
     fn rtp_header_layout() {
-        let sk = SessionKey {
-            key: [0; 16],
-            iv: [0; 16],
-        };
+        let cipher = Cipher::None;
         // Empty ALAC frame so we can inspect the header byte-by-byte.
-        let pkt = build_rtp_packet(0x1234, 0xABCD_0123, 0xDEAD_BEEF, true, &[], &sk);
+        let pkt = build_rtp_packet(0x1234, 0xABCD_0123, 0xDEAD_BEEF, true, &[], &cipher);
         assert_eq!(pkt.len(), 12);
         assert_eq!(pkt[0], 0x80); // V=2 P=0 X=0 CC=0
         assert_eq!(pkt[1], 0x80 | 0x60); // marker + PT=96
@@ -293,11 +293,16 @@ mod tests {
 
     #[test]
     fn rtp_subsequent_packets_have_no_marker() {
-        let sk = SessionKey {
-            key: [0; 16],
-            iv: [0; 16],
-        };
-        let pkt = build_rtp_packet(0, 0, 0, false, &[], &sk);
+        let cipher = Cipher::None;
+        let pkt = build_rtp_packet(0, 0, 0, false, &[], &cipher);
         assert_eq!(pkt[1], 0x60); // PT=96, no marker
+    }
+
+    #[test]
+    fn rtp_unencrypted_payload_is_passed_through() {
+        let cipher = Cipher::None;
+        let payload = [0xAA, 0xBB, 0xCC, 0xDD];
+        let pkt = build_rtp_packet(0, 0, 0, false, &payload, &cipher);
+        assert_eq!(&pkt[12..], &payload);
     }
 }

--- a/service/src/airplay/rtsp.rs
+++ b/service/src/airplay/rtsp.rs
@@ -1,0 +1,445 @@
+//! RTSP/1.0 client for the AirPlay control plane.
+//!
+//! One persistent TCP connection per session. Synchronous request /
+//! response — no pipelining. We hand-roll the protocol because
+//! standard HTTP libraries don't speak RTSP's verb set (ANNOUNCE,
+//! SETUP, RECORD, FLUSH, TEARDOWN, SET_PARAMETER) and a couple of
+//! mandatory headers (CSeq, Apple-Challenge, Active-Remote, DACP-ID).
+//!
+//! ## Sequence
+//!
+//! ```text
+//!   OPTIONS *                       — verify reachable, send Apple-Challenge
+//!   ANNOUNCE rtsp://ip/<sess>       — declare codec + rsaaeskey + aesiv (SDP)
+//!   SETUP    rtsp://ip/<sess>       — request RTP/UDP server ports
+//!   RECORD   rtsp://ip/<sess>       — flip to streaming
+//!     (... audio packets on UDP in parallel ...)
+//!   SET_PARAMETER rtsp://ip/<sess>  — volume
+//!   TEARDOWN rtsp://ip/<sess>       — close
+//! ```
+
+use anyhow::{anyhow, bail, Context, Result};
+use log::{debug, warn};
+use rand::Rng;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::time::Duration;
+
+use crate::airplay::crypto::{base64_nopad, random_apple_challenge, SessionKey};
+
+/// User-Agent string the RTSP requests carry.
+///
+/// Several RAOP receivers (notably some Sonos firmware revisions) gate
+/// playback on a recognised iTunes-style identifier. We send the well-
+/// known iTunes 7.6 string used by every open-source sender in the
+/// wild — receivers treat it as known-good. The actual product
+/// identity is carried in `Client-Instance` / DACP-ID so receivers
+/// that DO want our identity can pick it up.
+const RTSP_USER_AGENT: &str = "iTunes/7.6.2 (Windows; N;)";
+
+/// SDP "session id" — the random 64-bit number we identify our session
+/// by, both in the ANNOUNCE URL and the SDP `o=` line. Once chosen at
+/// session start, fixed for the lifetime of the session.
+pub type SessionId = u64;
+
+/// SETUP response — the server tells us which UDP ports it bound for
+/// audio data, control (sync) and timing.
+#[derive(Debug, Clone, Copy)]
+pub struct ServerPorts {
+    pub audio: u16,
+    pub control: u16,
+    pub timing: u16,
+}
+
+/// A live RTSP control connection.
+pub struct RtspClient {
+    stream: TcpStream,
+    cseq: u32,
+    /// Receiver IP, used in URI and SDP origin field.
+    receiver_ip: IpAddr,
+    /// Local IP, used in SDP `o=` line.
+    local_ip: IpAddr,
+    /// Persistent session id.
+    pub session_id: SessionId,
+    /// Per-receiver client instance id (UUID-like 8-byte hex). Apple's
+    /// receivers gate certain features on this being stable across
+    /// requests within the session.
+    pub client_instance: String,
+    /// DACP-ID — the iTunes Direct Audio Control Protocol session id,
+    /// a fixed 16-hex-char identifier. Some receivers gate playback on
+    /// its presence even though we don't currently handle the DACP
+    /// callback channel.
+    pub dacp_id: String,
+    /// Active-Remote header value, paired with DACP-ID. Receivers send
+    /// remote-control requests (volume up, play/pause) back to us via
+    /// this token.
+    pub active_remote: String,
+    /// Session token returned by the server in the SETUP response;
+    /// echoed in every subsequent request's Session header.
+    pub session_token: Option<String>,
+}
+
+impl RtspClient {
+    /// Open a TCP connection to the receiver, derive the per-session
+    /// identifiers, and prepare for the OPTIONS handshake.
+    pub fn connect(
+        receiver_ip: IpAddr,
+        port: u16,
+        local_ip: IpAddr,
+        timeout: Duration,
+    ) -> Result<Self> {
+        let addr = SocketAddr::new(receiver_ip, port);
+        let stream = TcpStream::connect_timeout(&addr, timeout)
+            .with_context(|| format!("connecting RTSP control TCP to {}", addr))?;
+        stream.set_read_timeout(Some(timeout))?;
+        stream.set_write_timeout(Some(timeout))?;
+
+        let mut rng = rand::thread_rng();
+        let session_id: u64 = rng.gen();
+        let client_instance = format!("{:016X}", rng.gen::<u64>());
+        let dacp_id = format!("{:016X}", rng.gen::<u64>());
+        let active_remote = format!("{}", rng.gen::<u32>());
+
+        Ok(Self {
+            stream,
+            cseq: 0,
+            receiver_ip,
+            local_ip,
+            session_id,
+            client_instance,
+            dacp_id,
+            active_remote,
+            session_token: None,
+        })
+    }
+
+    /// Construct the per-session URI used in ANNOUNCE/SETUP/RECORD/TEARDOWN.
+    fn session_uri(&self) -> String {
+        format!("rtsp://{}/{}", self.receiver_ip, self.session_id)
+    }
+
+    /// Send OPTIONS * with an Apple-Challenge nonce. The receiver will
+    /// respond with `Apple-Response: <base64-rsa-signed-nonce>`. We
+    /// don't currently verify the signature (it would require Apple's
+    /// public key for *verification*, which we don't have a clean way
+    /// to derive — receivers sign with their own key); just sending
+    /// the challenge is sufficient to make most receivers happy.
+    pub fn options(&mut self) -> Result<()> {
+        let challenge = random_apple_challenge();
+        let challenge_b64 = base64_nopad(&challenge);
+        let extra = vec![("Apple-Challenge".to_string(), challenge_b64)];
+        let resp = self.request("OPTIONS", "*", &extra, "")?;
+        debug!(
+            "RTSP OPTIONS: Public='{}', Apple-Response present: {}",
+            resp.headers.get("public").map(|s| s.as_str()).unwrap_or(""),
+            resp.headers.contains_key("apple-response"),
+        );
+        Ok(())
+    }
+
+    /// ANNOUNCE — send the SDP that declares our codec and ships the
+    /// RSA-wrapped AES key + IV.
+    ///
+    /// SDP format:
+    ///
+    /// ```text
+    /// v=0
+    /// o=stream-to-speaker <session_id> 0 IN IP4 <local_ip>
+    /// s=stream-to-speaker
+    /// c=IN IP4 <receiver_ip>
+    /// t=0 0
+    /// m=audio 0 RTP/AVP 96
+    /// a=rtpmap:96 AppleLossless
+    /// a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100
+    /// a=rsaaeskey:<base64-nopad of 128-byte RSA-OAEP ciphertext>
+    /// a=aesiv:<base64-nopad of 16-byte IV>
+    /// ```
+    pub fn announce(&mut self, session_key: &SessionKey) -> Result<()> {
+        let rsa_wrapped = session_key.rsa_wrapped_key()?;
+        let key_b64 = base64_nopad(&rsa_wrapped);
+        let iv_b64 = base64_nopad(&session_key.iv);
+
+        let sdp = format!(
+            "v=0\r\n\
+             o=stream-to-speaker {sid} 0 IN IP4 {local}\r\n\
+             s=stream-to-speaker\r\n\
+             c=IN IP4 {receiver}\r\n\
+             t=0 0\r\n\
+             m=audio 0 RTP/AVP 96\r\n\
+             a=rtpmap:96 AppleLossless\r\n\
+             a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100\r\n\
+             a=rsaaeskey:{key}\r\n\
+             a=aesiv:{iv}\r\n",
+            sid = self.session_id,
+            local = self.local_ip,
+            receiver = self.receiver_ip,
+            key = key_b64,
+            iv = iv_b64,
+        );
+
+        let uri = self.session_uri();
+        let extra = vec![(
+            "Content-Type".to_string(),
+            "application/sdp".to_string(),
+        )];
+        let resp = self.request("ANNOUNCE", &uri, &extra, &sdp)?;
+        if resp.status_code != 200 {
+            bail!("ANNOUNCE failed: {} {}", resp.status_code, resp.status_text);
+        }
+        Ok(())
+    }
+
+    /// SETUP — request RTP/UDP transport, telling the server which
+    /// local UDP ports we'll send/listen on. Parses the server's
+    /// `Transport: ...;server_port=X;control_port=Y;timing_port=Z` to
+    /// get the receiver's port assignments.
+    pub fn setup(
+        &mut self,
+        client_control_port: u16,
+        client_timing_port: u16,
+    ) -> Result<ServerPorts> {
+        let uri = self.session_uri();
+        let transport = format!(
+            "RTP/AVP/UDP;unicast;interleaved=0-1;mode=record;control_port={};timing_port={}",
+            client_control_port, client_timing_port
+        );
+        let extra = vec![("Transport".to_string(), transport)];
+        let resp = self.request("SETUP", &uri, &extra, "")?;
+        if resp.status_code != 200 {
+            bail!("SETUP failed: {} {}", resp.status_code, resp.status_text);
+        }
+        // Capture the Session token for subsequent requests.
+        if let Some(sess) = resp.headers.get("session") {
+            // Format: "<token>;timeout=60"
+            let token = sess.split(';').next().unwrap_or(sess).trim().to_string();
+            self.session_token = Some(token);
+        }
+        let transport = resp
+            .headers
+            .get("transport")
+            .ok_or_else(|| anyhow!("SETUP response missing Transport header"))?;
+
+        let mut server_port = None;
+        let mut control_port = None;
+        let mut timing_port = None;
+        for part in transport.split(';') {
+            let (k, v) = match part.split_once('=') {
+                Some(kv) => kv,
+                None => continue,
+            };
+            match k.trim() {
+                "server_port" => server_port = v.split('-').next().and_then(|s| s.parse().ok()),
+                "control_port" => control_port = v.parse().ok(),
+                "timing_port" => timing_port = v.parse().ok(),
+                _ => {}
+            }
+        }
+        let audio = server_port.ok_or_else(|| anyhow!("SETUP: no server_port in transport"))?;
+        let control = control_port.unwrap_or(audio);
+        let timing = timing_port.unwrap_or(audio);
+        Ok(ServerPorts { audio, control, timing })
+    }
+
+    /// RECORD — flip the receiver to "expect audio". `initial_seq` and
+    /// `initial_rtptime` go in the `RTP-Info` header so the receiver
+    /// can prime its jitter buffer.
+    pub fn record(&mut self, initial_seq: u16, initial_rtptime: u32) -> Result<()> {
+        let uri = self.session_uri();
+        let extra = vec![
+            ("Range".to_string(), "npt=0-".to_string()),
+            (
+                "RTP-Info".to_string(),
+                format!("seq={};rtptime={}", initial_seq, initial_rtptime),
+            ),
+        ];
+        let resp = self.request("RECORD", &uri, &extra, "")?;
+        if resp.status_code != 200 {
+            bail!("RECORD failed: {} {}", resp.status_code, resp.status_text);
+        }
+        Ok(())
+    }
+
+    /// SET_PARAMETER volume — RAOP volume is a float in dB, ranging
+    /// from -30.0 (very quiet) to 0.0 (loud), with the sentinel
+    /// -144.0 meaning fully muted.
+    pub fn set_volume(&mut self, db: f32) -> Result<()> {
+        let body = format!("volume: {:.6}\r\n", db);
+        let uri = self.session_uri();
+        let extra = vec![(
+            "Content-Type".to_string(),
+            "text/parameters".to_string(),
+        )];
+        let resp = self.request("SET_PARAMETER", &uri, &extra, &body)?;
+        if resp.status_code != 200 {
+            bail!("SET_PARAMETER volume failed: {} {}", resp.status_code, resp.status_text);
+        }
+        Ok(())
+    }
+
+    /// FLUSH — tell the receiver to drop everything it has buffered up
+    /// to `seq`. We use this when restarting playback after a pause.
+    pub fn flush(&mut self, seq: u16, rtptime: u32) -> Result<()> {
+        let uri = self.session_uri();
+        let extra = vec![(
+            "RTP-Info".to_string(),
+            format!("seq={};rtptime={}", seq, rtptime),
+        )];
+        let resp = self.request("FLUSH", &uri, &extra, "")?;
+        if resp.status_code != 200 {
+            bail!("FLUSH failed: {} {}", resp.status_code, resp.status_text);
+        }
+        Ok(())
+    }
+
+    /// TEARDOWN — close the session. Best-effort; receivers eventually
+    /// time out anyway. We swallow errors so a half-broken receiver
+    /// doesn't block shutdown.
+    pub fn teardown(&mut self) {
+        let uri = self.session_uri();
+        if let Err(e) = self.request("TEARDOWN", &uri, &[], "") {
+            warn!("RTSP TEARDOWN failed (continuing anyway): {}", e);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------
+
+    fn request(
+        &mut self,
+        method: &str,
+        uri: &str,
+        extra_headers: &[(String, String)],
+        body: &str,
+    ) -> Result<RtspResponse> {
+        self.cseq += 1;
+        let mut req = String::new();
+        req.push_str(&format!("{} {} RTSP/1.0\r\n", method, uri));
+        req.push_str(&format!("CSeq: {}\r\n", self.cseq));
+        req.push_str(&format!("User-Agent: {}\r\n", RTSP_USER_AGENT));
+        req.push_str(&format!("Client-Instance: {}\r\n", self.client_instance));
+        req.push_str(&format!("DACP-ID: {}\r\n", self.dacp_id));
+        req.push_str(&format!("Active-Remote: {}\r\n", self.active_remote));
+        if let Some(token) = &self.session_token {
+            req.push_str(&format!("Session: {}\r\n", token));
+        }
+        for (k, v) in extra_headers {
+            req.push_str(&format!("{}: {}\r\n", k, v));
+        }
+        if !body.is_empty() {
+            req.push_str(&format!("Content-Length: {}\r\n", body.len()));
+        }
+        req.push_str("\r\n");
+        req.push_str(body);
+
+        debug!(
+            "RTSP > {} {} (CSeq={}, body={}B)",
+            method,
+            uri,
+            self.cseq,
+            body.len()
+        );
+        self.stream.write_all(req.as_bytes())?;
+        self.stream.flush()?;
+        read_response(&mut self.stream)
+    }
+}
+
+#[derive(Debug)]
+pub struct RtspResponse {
+    pub status_code: u16,
+    pub status_text: String,
+    /// Lower-cased header names → trimmed values.
+    pub headers: HashMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+/// Read one RTSP/1.0 response off the stream. RTSP/1.0 framing matches
+/// HTTP/1.0 closely: status line + headers + optional body delimited
+/// by Content-Length.
+fn read_response(stream: &mut TcpStream) -> Result<RtspResponse> {
+    let mut buf = Vec::with_capacity(2048);
+    let mut tmp = [0u8; 1024];
+    let header_end;
+    loop {
+        let n = stream.read(&mut tmp)?;
+        if n == 0 {
+            bail!("RTSP connection closed while waiting for response");
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if let Some(pos) = find_header_end(&buf) {
+            header_end = pos;
+            break;
+        }
+        if buf.len() > 64 * 1024 {
+            bail!("RTSP response headers too large ({} bytes, no end)", buf.len());
+        }
+    }
+
+    let head = std::str::from_utf8(&buf[..header_end])
+        .map_err(|_| anyhow!("RTSP response headers were not UTF-8"))?
+        .to_string();
+    let mut lines = head.lines();
+    let status_line = lines.next().ok_or_else(|| anyhow!("empty status line"))?;
+    let (status_code, status_text) = parse_status_line(status_line)?;
+    let mut headers: HashMap<String, String> = HashMap::new();
+    for line in lines {
+        if let Some((k, v)) = line.split_once(':') {
+            headers.insert(k.trim().to_ascii_lowercase(), v.trim().to_string());
+        }
+    }
+    let content_length = headers
+        .get("content-length")
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(0);
+    let body_start = header_end + 4; // "\r\n\r\n"
+    let mut body = buf[body_start..].to_vec();
+    while body.len() < content_length {
+        let need = content_length - body.len();
+        let read_cap = tmp.len().min(need);
+        let n = stream.read(&mut tmp[..read_cap])?;
+        if n == 0 {
+            bail!(
+                "RTSP body short read: got {} of {} bytes",
+                body.len(),
+                content_length
+            );
+        }
+        body.extend_from_slice(&tmp[..n]);
+    }
+    body.truncate(content_length);
+
+    debug!(
+        "RTSP < {} {} ({} headers, {}B body)",
+        status_code,
+        status_text,
+        headers.len(),
+        body.len()
+    );
+    Ok(RtspResponse {
+        status_code,
+        status_text,
+        headers,
+        body,
+    })
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn parse_status_line(line: &str) -> Result<(u16, String)> {
+    let mut parts = line.splitn(3, ' ');
+    let _proto = parts
+        .next()
+        .ok_or_else(|| anyhow!("status line missing protocol"))?;
+    let code_str = parts
+        .next()
+        .ok_or_else(|| anyhow!("status line missing code"))?;
+    let text = parts.next().unwrap_or("").to_string();
+    let code: u16 = code_str
+        .parse()
+        .with_context(|| format!("parsing status code {:?}", code_str))?;
+    Ok((code, text))
+}

--- a/service/src/airplay/rtsp.rs
+++ b/service/src/airplay/rtsp.rs
@@ -26,7 +26,7 @@ use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr, TcpStream};
 use std::time::Duration;
 
-use crate::airplay::crypto::{base64_nopad, random_apple_challenge, SessionKey};
+use crate::airplay::crypto::{base64_nopad, random_apple_challenge, Cipher};
 
 /// User-Agent string the RTSP requests carry.
 ///
@@ -138,44 +138,54 @@ impl RtspClient {
         Ok(())
     }
 
-    /// ANNOUNCE — send the SDP that declares our codec and ships the
-    /// RSA-wrapped AES key + IV.
+    /// ANNOUNCE — send the SDP that declares our codec and (for the
+    /// encrypted path) ships the RSA-wrapped AES key + IV.
     ///
-    /// SDP format:
+    /// SDP format (`o=` and `s=` say "iTunes" because some receivers,
+    /// notably some Sonos AP2 firmwares, gate on the iTunes brand;
+    /// our real identity goes in `Client-Instance`/`DACP-ID`):
     ///
     /// ```text
     /// v=0
-    /// o=stream-to-speaker <session_id> 0 IN IP4 <local_ip>
-    /// s=stream-to-speaker
+    /// o=iTunes <session_id> 0 IN IP4 <local_ip>
+    /// s=iTunes
     /// c=IN IP4 <receiver_ip>
     /// t=0 0
     /// m=audio 0 RTP/AVP 96
     /// a=rtpmap:96 AppleLossless
     /// a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100
-    /// a=rsaaeskey:<base64-nopad of 128-byte RSA-OAEP ciphertext>
-    /// a=aesiv:<base64-nopad of 16-byte IV>
+    /// [a=rsaaeskey:<base64-nopad of 256-byte RSA-OAEP ciphertext>]
+    /// [a=aesiv:<base64-nopad of 16-byte IV>]
     /// ```
-    pub fn announce(&mut self, session_key: &SessionKey) -> Result<()> {
-        let rsa_wrapped = session_key.rsa_wrapped_key()?;
-        let key_b64 = base64_nopad(&rsa_wrapped);
-        let iv_b64 = base64_nopad(&session_key.iv);
+    ///
+    /// The last two lines are only emitted for [`Cipher::AesRsa`].
+    /// For [`Cipher::None`] the receiver expects raw (unencrypted)
+    /// audio RTP packets and we skip the SDP key material entirely.
+    pub fn announce(&mut self, cipher: &Cipher) -> Result<()> {
+        let crypto_lines = match cipher {
+            Cipher::None => String::new(),
+            Cipher::AesRsa(key) => {
+                let rsa_wrapped = key.rsa_wrapped_key()?;
+                let key_b64 = base64_nopad(&rsa_wrapped);
+                let iv_b64 = base64_nopad(&key.iv);
+                format!("a=rsaaeskey:{}\r\na=aesiv:{}\r\n", key_b64, iv_b64)
+            }
+        };
 
         let sdp = format!(
             "v=0\r\n\
-             o=stream-to-speaker {sid} 0 IN IP4 {local}\r\n\
-             s=stream-to-speaker\r\n\
+             o=iTunes {sid} 0 IN IP4 {local}\r\n\
+             s=iTunes\r\n\
              c=IN IP4 {receiver}\r\n\
              t=0 0\r\n\
              m=audio 0 RTP/AVP 96\r\n\
              a=rtpmap:96 AppleLossless\r\n\
              a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100\r\n\
-             a=rsaaeskey:{key}\r\n\
-             a=aesiv:{iv}\r\n",
+             {crypto}",
             sid = self.session_id,
             local = self.local_ip,
             receiver = self.receiver_ip,
-            key = key_b64,
-            iv = iv_b64,
+            crypto = crypto_lines,
         );
 
         let uri = self.session_uri();

--- a/service/src/airplay/session.rs
+++ b/service/src/airplay/session.rs
@@ -1,0 +1,280 @@
+//! High-level AirPlay session lifecycle.
+//!
+//! Mirrors `app::start_session` / `app::stop_session` for the UPnP
+//! path. One `AirPlaySession` owns one open RTSP connection, three UDP
+//! sockets (audio, control, timing), and the background audio sender
+//! thread. Dropping the session tears it all down.
+
+use anyhow::{Context, Result};
+use crossbeam_channel::Receiver;
+use log::{debug, info, warn};
+use std::net::{IpAddr, SocketAddr, UdpSocket};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use crate::airplay::crypto::SessionKey;
+use crate::airplay::discovery::AirPlayRenderer;
+use crate::airplay::rtp::{
+    bind_udp, random_initial_rtptime, random_initial_seq, random_ssrc, spawn_audio_sender,
+    RtpSenderConfig,
+};
+use crate::airplay::rtsp::RtspClient;
+use crate::airplay::timing::{spawn_sync_sender, spawn_timing_responder};
+use crate::http_server::PcmFrame;
+
+/// Default receiver-advertised playback latency in samples, used for
+/// sync-packet anchor calculation when the receiver doesn't return an
+/// `Audio-Latency` header. 11025 samples = 250 ms at 44.1 kHz.
+const DEFAULT_LATENCY_SAMPLES: u32 = 11025;
+
+/// Configuration to spin up one AirPlay session.
+pub struct AirPlaySessionConfig {
+    pub renderer: AirPlayRenderer,
+    /// Local IPv4 we'll bind UDP sockets to and advertise in SDP. Same
+    /// IP we already use for `advertise_ip` on the HTTP side.
+    pub local_ip: IpAddr,
+    /// Subscription on the StreamHub — produces PcmFrame entries the
+    /// audio thread consumes.
+    pub samples_rx: Receiver<PcmFrame>,
+    /// Initial volume in [0, 100] — converted to RAOP dB internally.
+    pub initial_volume: Option<u32>,
+}
+
+/// Live AirPlay session.
+pub struct AirPlaySession {
+    pub renderer: AirPlayRenderer,
+    /// Held under a Mutex so volume commands from arbitrary threads
+    /// can serialise into the single RTSP connection.
+    rtsp: Arc<Mutex<RtspClient>>,
+    /// Signals every background thread to stop (audio sender, timing
+    /// responder, sync sender).
+    stop_flag: Arc<AtomicBool>,
+    /// Handles on the three background threads. Stored as Options so
+    /// `stop()` can take them out of the session before joining.
+    sender_handle: Option<JoinHandle<()>>,
+    timing_handle: Option<JoinHandle<()>>,
+    sync_handle: Option<JoinHandle<()>>,
+    /// Hold the audio socket so it isn't closed prematurely; the
+    /// sender thread holds a `try_clone` for sending. Once `stop`
+    /// runs we drop these in the right order to wake any blocked
+    /// background thread.
+    _audio_socket: UdpSocket,
+}
+
+impl AirPlaySession {
+    /// Open the full RAOP session: RTSP handshake, allocate UDP
+    /// sockets, RECORD, and spawn the audio thread. Returns once audio
+    /// is being delivered.
+    pub fn start(cfg: AirPlaySessionConfig) -> Result<Self> {
+        info!(
+            "AirPlay: starting session to {} ({}:{})",
+            cfg.renderer.friendly_name, cfg.renderer.ip, cfg.renderer.port,
+        );
+
+        if !cfg.renderer.is_supported() {
+            return Err(anyhow::anyhow!(
+                "speaker {} doesn't advertise a codec/encryption pair we support \
+                 (codecs={:?}, et={:?}, password={})",
+                cfg.renderer.friendly_name,
+                cfg.renderer.codecs,
+                cfg.renderer.encryption_types,
+                cfg.renderer.password_protected,
+            ));
+        }
+
+        // Bind the three UDP sockets first so we know our ports for SETUP.
+        let audio_socket = bind_udp(cfg.local_ip).context("bind audio UDP")?;
+        let control_socket = bind_udp(cfg.local_ip).context("bind control UDP")?;
+        let timing_socket = bind_udp(cfg.local_ip).context("bind timing UDP")?;
+        let audio_port = audio_socket.local_addr()?.port();
+        let control_port = control_socket.local_addr()?.port();
+        let timing_port = timing_socket.local_addr()?.port();
+        debug!(
+            "AirPlay UDP sockets bound: audio={}, control={}, timing={}",
+            audio_port, control_port, timing_port
+        );
+
+        let mut rtsp = RtspClient::connect(
+            cfg.renderer.ip,
+            cfg.renderer.port,
+            cfg.local_ip,
+            Duration::from_secs(5),
+        )
+        .context("opening RTSP connection")?;
+        rtsp.options().context("RTSP OPTIONS")?;
+
+        let session_key = SessionKey::random();
+        rtsp.announce(&session_key).context("RTSP ANNOUNCE")?;
+
+        let server_ports = rtsp
+            .setup(control_port, timing_port)
+            .context("RTSP SETUP")?;
+        debug!(
+            "AirPlay SETUP returned server ports: audio={}, control={}, timing={}",
+            server_ports.audio, server_ports.control, server_ports.timing,
+        );
+
+        // Random initial RTP state for this session.
+        let initial_seq = random_initial_seq();
+        let initial_rtptime = random_initial_rtptime();
+        let ssrc = random_ssrc();
+        rtsp.record(initial_seq, initial_rtptime)
+            .context("RTSP RECORD")?;
+
+        if let Some(vol) = cfg.initial_volume {
+            // Best-effort — don't fail the session if the volume set
+            // bounces (some receivers are picky about timing).
+            let db = volume_pct_to_raop_db(vol);
+            if let Err(e) = rtsp.set_volume(db) {
+                warn!("AirPlay SET_PARAMETER volume failed: {}", e);
+            }
+        }
+
+        // Spin up the three background threads. The audio sender owns
+        // a try_clone of the audio socket; timing + sync own their
+        // respective sockets outright (we don't need to keep them in
+        // the session struct because the threads block on them).
+        let audio_socket_for_thread = audio_socket
+            .try_clone()
+            .context("try_clone audio socket")?;
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let current_rtptime = Arc::new(AtomicU32::new(initial_rtptime));
+
+        let sender_cfg = RtpSenderConfig {
+            audio_socket: audio_socket_for_thread,
+            receiver_addr: SocketAddr::new(cfg.renderer.ip, server_ports.audio),
+            session_key,
+            initial_seq,
+            initial_rtptime,
+            ssrc,
+            samples_rx: cfg.samples_rx,
+            stop_flag: stop_flag.clone(),
+            receiver_name: cfg.renderer.friendly_name.clone(),
+            current_rtptime: current_rtptime.clone(),
+        };
+        let sender_handle = spawn_audio_sender(sender_cfg)?;
+
+        let timing_handle = spawn_timing_responder(
+            timing_socket,
+            stop_flag.clone(),
+            cfg.renderer.friendly_name.clone(),
+        )
+        .context("spawning AirPlay timing responder")?;
+
+        let sync_handle = spawn_sync_sender(
+            control_socket,
+            SocketAddr::new(cfg.renderer.ip, server_ports.control),
+            current_rtptime,
+            DEFAULT_LATENCY_SAMPLES,
+            stop_flag.clone(),
+            cfg.renderer.friendly_name.clone(),
+        )
+        .context("spawning AirPlay sync sender")?;
+
+        info!(
+            "AirPlay: session up — {} ↔ {}:{} (RTSP), audio → {}:{}, control → :{}, timing → :{}",
+            cfg.local_ip,
+            cfg.renderer.ip,
+            cfg.renderer.port,
+            cfg.renderer.ip,
+            server_ports.audio,
+            server_ports.control,
+            server_ports.timing,
+        );
+
+        Ok(Self {
+            renderer: cfg.renderer,
+            rtsp: Arc::new(Mutex::new(rtsp)),
+            stop_flag,
+            sender_handle: Some(sender_handle),
+            timing_handle: Some(timing_handle),
+            sync_handle: Some(sync_handle),
+            _audio_socket: audio_socket,
+        })
+    }
+
+    /// Push a new volume value (0..=100) to the receiver. Idempotent
+    /// across repeats; receivers throttle their own UI updates.
+    pub fn set_volume_pct(&self, vol: u32) -> Result<()> {
+        let db = volume_pct_to_raop_db(vol);
+        self.rtsp.lock().unwrap().set_volume(db)
+    }
+
+    /// Push a mute state. RAOP doesn't have a separate mute parameter,
+    /// just the sentinel -144 dB "off" volume.
+    pub fn set_mute(&self, muted: bool) -> Result<()> {
+        let db = if muted { -144.0 } else { 0.0 };
+        self.rtsp.lock().unwrap().set_volume(db)
+    }
+
+    /// Tear down: stop the background threads, TEARDOWN RTSP, close
+    /// sockets. Best-effort — receivers will eventually time us out
+    /// even if we skip this; it's here for clean shutdown only.
+    pub fn stop(mut self) {
+        info!(
+            "AirPlay: stopping session to {}",
+            self.renderer.friendly_name
+        );
+        self.stop_flag.store(true, Ordering::Release);
+        for h in [
+            self.sender_handle.take(),
+            self.timing_handle.take(),
+            self.sync_handle.take(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let _ = h.join();
+        }
+        let mut guard = self.rtsp.lock().unwrap();
+        guard.teardown();
+    }
+}
+
+impl Drop for AirPlaySession {
+    fn drop(&mut self) {
+        // Belt-and-braces: ensure the audio thread is told to stop if
+        // someone drops a session without calling `stop`.
+        self.stop_flag.store(true, Ordering::Release);
+    }
+}
+
+/// Convert a 0..=100 percent volume to a RAOP-protocol dB value.
+///
+/// RAOP volume semantics:
+///   *  0%   → -144.0 (sentinel "mute")
+///   *  1%   → -30.0  (quietest non-muted)
+///   * 100%  →   0.0  (loudest)
+///
+/// Interpolation between 1 and 100 is linear in dB. This matches
+/// PulseAudio's RAOP sink and the iTunes reference.
+pub fn volume_pct_to_raop_db(pct: u32) -> f32 {
+    let pct = pct.min(100);
+    if pct == 0 {
+        return -144.0;
+    }
+    // Linear in dB from -30 (1%) to 0 (100%) over 99 steps.
+    let pct_f = pct as f32;
+    -30.0 + (pct_f - 1.0) * (30.0 / 99.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn volume_mapping_anchor_points() {
+        assert_eq!(volume_pct_to_raop_db(0), -144.0);
+        assert!((volume_pct_to_raop_db(1) - -30.0).abs() < 1e-4);
+        assert!((volume_pct_to_raop_db(100) - 0.0).abs() < 1e-4);
+        // Monotonic
+        let mut prev = volume_pct_to_raop_db(1);
+        for p in 2..=100 {
+            let v = volume_pct_to_raop_db(p);
+            assert!(v > prev, "non-monotonic at {}: {} → {}", p, prev, v);
+            prev = v;
+        }
+    }
+}

--- a/service/src/airplay/session.rs
+++ b/service/src/airplay/session.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use crate::airplay::crypto::SessionKey;
+use crate::airplay::crypto::Cipher;
 use crate::airplay::discovery::AirPlayRenderer;
 use crate::airplay::rtp::{
     bind_udp, random_initial_rtptime, random_initial_seq, random_ssrc, spawn_audio_sender,
@@ -105,8 +105,20 @@ impl AirPlaySession {
         .context("opening RTSP connection")?;
         rtsp.options().context("RTSP OPTIONS")?;
 
-        let session_key = SessionKey::random();
-        rtsp.announce(&session_key).context("RTSP ANNOUNCE")?;
+        let cipher = Cipher::pick_for(&cfg.renderer.encryption_types).ok_or_else(|| {
+            anyhow::anyhow!(
+                "no compatible encryption mode for {} (advertised et={:?})",
+                cfg.renderer.friendly_name,
+                cfg.renderer.encryption_types,
+            )
+        })?;
+        info!(
+            "AirPlay: cipher={} (receiver et={:?})",
+            cipher.label(),
+            cfg.renderer.encryption_types,
+        );
+        let cipher = Arc::new(cipher);
+        rtsp.announce(&cipher).context("RTSP ANNOUNCE")?;
 
         let server_ports = rtsp
             .setup(control_port, timing_port)
@@ -145,7 +157,7 @@ impl AirPlaySession {
         let sender_cfg = RtpSenderConfig {
             audio_socket: audio_socket_for_thread,
             receiver_addr: SocketAddr::new(cfg.renderer.ip, server_ports.audio),
-            session_key,
+            cipher,
             initial_seq,
             initial_rtptime,
             ssrc,

--- a/service/src/airplay/timing.rs
+++ b/service/src/airplay/timing.rs
@@ -1,0 +1,200 @@
+//! Sync + timing packet handlers.
+//!
+//! Two concurrent UDP responsibilities:
+//!
+//! ## Timing channel (required)
+//!
+//! The receiver periodically sends a 32-byte timing **request** to
+//! our `timing_port`. We must echo a 32-byte **response** within a
+//! sensible window — failure to respond causes most receivers to
+//! drift audibly or drop the session within ~10 seconds.
+//!
+//! Request layout (32 bytes):
+//!
+//! ```text
+//!  0..1  : 0x80                 # V=2
+//!  1..2  : 0xD2                 # M=1, PT=82=0x52 (timing request)
+//!  2..4  : sequence (BE u16)
+//!  4..8  : zero padding
+//!  8..16 : zero / "origin"
+//! 16..24 : zero / "received"
+//! 24..32 : NTP timestamp of when the receiver sent this  (echo back)
+//! ```
+//!
+//! Response layout (32 bytes):
+//!
+//! ```text
+//!  0..1  : 0x80
+//!  1..2  : 0xD3                 # M=1, PT=83=0x53 (timing response)
+//!  2..4  : 0x0007               # constant
+//!  4..8  : zero padding
+//!  8..16 : NTP "reference"   ← copy bytes 24..32 of request
+//! 16..24 : NTP "received"    ← capture immediately at recv
+//! 24..32 : NTP "transmit"    ← capture immediately before send
+//! ```
+//!
+//! ## Sync channel (advisory)
+//!
+//! We send a sync packet to the receiver's `control_port` roughly
+//! once a second to keep its drift estimator anchored. Most receivers
+//! cope without this in the short term but eventually re-buffer or
+//! glitch without it.
+//!
+//! Sync packet layout (20 bytes):
+//!
+//! ```text
+//!  0..1  : 0x80 (or 0x90 on first packet, X bit set)
+//!  1..2  : 0xD4                 # M=1, PT=84=0x54
+//!  2..4  : 0x0007               # constant
+//!  4..8  : RTP timestamp − latency (BE u32) — "now should be playing"
+//!  8..16 : NTP timestamp of now
+//! 16..20 : current RTP timestamp (BE u32) — "now being sent"
+//! ```
+
+use byteorder::{BigEndian, ByteOrder};
+use log::{debug, warn};
+use std::net::{SocketAddr, UdpSocket};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// NTP epoch offset — seconds between 1900-01-01 and 1970-01-01.
+const NTP_EPOCH_OFFSET: u64 = 2_208_988_800;
+
+/// Sequence value RAOP uses for sync + timing responses. The receiver
+/// only checks this on timing requests it sends; for our responses
+/// the constant 7 is what every reference implementation uses.
+const RAOP_FIXED_SEQ: u16 = 7;
+
+/// Convert `SystemTime::now()` to a 64-bit NTP timestamp (seconds
+/// since 1900-01-01 in the high 32 bits, fractional seconds in the
+/// low 32 bits). Saturates on broken clocks.
+pub fn ntp_now() -> u64 {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs() + NTP_EPOCH_OFFSET;
+    let frac = ((now.subsec_nanos() as u64) << 32) / 1_000_000_000;
+    (secs << 32) | frac
+}
+
+/// Spawn the timing responder. Owns the timing socket. Exits when
+/// `stop_flag` is set OR when the socket errors persistently.
+pub fn spawn_timing_responder(
+    timing_socket: UdpSocket,
+    stop_flag: Arc<AtomicBool>,
+    receiver_name: String,
+) -> std::io::Result<thread::JoinHandle<()>> {
+    timing_socket.set_read_timeout(Some(Duration::from_millis(500)))?;
+    thread::Builder::new()
+        .name(format!("stream-to-speaker-airplay-timing:{}", receiver_name))
+        .spawn(move || {
+            let mut buf = [0u8; 64];
+            while !stop_flag.load(Ordering::Acquire) {
+                match timing_socket.recv_from(&mut buf) {
+                    Ok((n, peer)) if n >= 32 => {
+                        let received_ntp = ntp_now();
+                        handle_timing_request(
+                            &buf[..n],
+                            peer,
+                            received_ntp,
+                            &timing_socket,
+                        );
+                    }
+                    Ok((n, _)) => {
+                        debug!("AirPlay timing: short packet ({} bytes), ignoring", n);
+                    }
+                    Err(e)
+                        if e.kind() == std::io::ErrorKind::WouldBlock
+                            || e.kind() == std::io::ErrorKind::TimedOut =>
+                    {
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!("AirPlay timing recv error: {}", e);
+                    }
+                }
+            }
+            debug!("AirPlay timing responder: exiting");
+        })
+}
+
+fn handle_timing_request(req: &[u8], peer: SocketAddr, received_ntp: u64, sock: &UdpSocket) {
+    // Sanity: byte 0 should be 0x80, byte 1 should be 0xD2 (timing
+    // request, M=1 PT=82). We accept anything as long as it's 32+ bytes
+    // — some receivers send slightly off values.
+    let mut resp = [0u8; 32];
+    resp[0] = 0x80;
+    resp[1] = 0xD3;
+    BigEndian::write_u16(&mut resp[2..4], RAOP_FIXED_SEQ);
+    // bytes 4..8 stay zero (padding)
+    // reference_time: echo the request's bytes 24..32 (the receiver's
+    // "transmit" timestamp).
+    resp[8..16].copy_from_slice(&req[24..32]);
+    // received_time: when we recv'd
+    BigEndian::write_u64(&mut resp[16..24], received_ntp);
+    // transmit_time: now (just before send)
+    let transmit_ntp = ntp_now();
+    BigEndian::write_u64(&mut resp[24..32], transmit_ntp);
+
+    if let Err(e) = sock.send_to(&resp, peer) {
+        warn!("AirPlay timing: failed to reply to {}: {}", peer, e);
+    }
+}
+
+/// Spawn the sync packet sender. Sends one 20-byte sync packet per
+/// second to the receiver's `control_port` until `stop_flag` is set.
+///
+/// Latency is the receiver-advertised buffer depth in samples
+/// (typically 11025 = 250 ms at 44.1 kHz) — we use it to compute the
+/// "now should be playing" anchor timestamp.
+pub fn spawn_sync_sender(
+    control_socket: UdpSocket,
+    receiver_addr: SocketAddr,
+    current_rtptime: Arc<AtomicU32>,
+    latency_samples: u32,
+    stop_flag: Arc<AtomicBool>,
+    receiver_name: String,
+) -> std::io::Result<thread::JoinHandle<()>> {
+    thread::Builder::new()
+        .name(format!("stream-to-speaker-airplay-sync:{}", receiver_name))
+        .spawn(move || {
+            // Brief delay before first sync packet so the RTP stream is
+            // already flowing — sending a sync ahead of any audio
+            // confuses some receivers.
+            thread::sleep(Duration::from_millis(500));
+            let mut first = true;
+            while !stop_flag.load(Ordering::Acquire) {
+                let now_ntp = ntp_now();
+                let cur_rtp = current_rtptime.load(Ordering::Acquire);
+                let anchor_rtp = cur_rtp.wrapping_sub(latency_samples);
+
+                let mut pkt = [0u8; 20];
+                pkt[0] = if first { 0x90 } else { 0x80 };
+                pkt[1] = 0xD4;
+                BigEndian::write_u16(&mut pkt[2..4], RAOP_FIXED_SEQ);
+                BigEndian::write_u32(&mut pkt[4..8], anchor_rtp);
+                BigEndian::write_u64(&mut pkt[8..16], now_ntp);
+                BigEndian::write_u32(&mut pkt[16..20], cur_rtp);
+                first = false;
+
+                if let Err(e) = control_socket.send_to(&pkt, receiver_addr) {
+                    warn!(
+                        "AirPlay sync send to {} failed: {}",
+                        receiver_addr, e
+                    );
+                }
+
+                // Sleep ~1 s, but in 100 ms slices so stop_flag is
+                // observed quickly during shutdown.
+                for _ in 0..10 {
+                    if stop_flag.load(Ordering::Acquire) {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                }
+            }
+            debug!("AirPlay sync sender: exiting");
+        })
+}

--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -258,13 +258,18 @@ impl App {
             for r in d.renderers() {
                 let id = r.stable_id();
                 let active = active_id.as_deref() == Some(id.as_str());
-                // Mark unsupported speakers (e.g. password-protected)
-                // with a parenthetical so the user can tell why
-                // selection might fail.
+                // Annotate the row so the user can tell why a click
+                // might fail. Otherwise we just tag the row "(AirPlay)"
+                // so the user knows they're picking the AirPlay path
+                // rather than UPnP for receivers that advertise both
+                // (Sonos does).
                 let name = if r.is_supported() {
                     format!("{} (AirPlay)", r.friendly_name)
                 } else if r.password_protected {
                     format!("{} (AirPlay, password-protected)", r.friendly_name)
+                } else if r.encryption_types.iter().any(|&e| e >= 3) {
+                    // FairPlay-only — HomePod / paired-HomeKit territory.
+                    format!("{} (AirPlay, requires HomeKit pairing)", r.friendly_name)
                 } else {
                     format!("{} (AirPlay, unsupported)", r.friendly_name)
                 };

--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -12,6 +12,9 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, AtomicU64, 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crate::airplay::{
+    AirPlayDiscoveryState, AirPlayRenderer, AirPlaySession, AirPlaySessionConfig,
+};
 use crate::gena::GenaManager;
 use crate::http_server::{SpeakerInfo, StreamHub};
 use crate::silence::DEFAULT_QUIESCENT_AFTER_PACKETS;
@@ -31,7 +34,71 @@ pub struct RendererSession {
     pub stream_uri: String,
 }
 
-pub type SharedSession = Arc<Mutex<Option<RendererSession>>>;
+/// Active session — either UPnP (pull-style, speaker fetches our HTTP
+/// stream) or AirPlay (push-style, we send RTP/UDP to the speaker).
+/// At most one of these is live at a time; switching tears down the
+/// old and brings up the new.
+pub enum ActiveSession {
+    Upnp(RendererSession),
+    AirPlay(AirPlaySession),
+}
+
+impl ActiveSession {
+    pub fn stable_id(&self) -> String {
+        match self {
+            ActiveSession::Upnp(s) => s.renderer.stable_id(),
+            ActiveSession::AirPlay(s) => s.renderer.stable_id(),
+        }
+    }
+
+    pub fn friendly_name(&self) -> String {
+        match self {
+            ActiveSession::Upnp(s) => s.renderer.friendly_name.clone(),
+            ActiveSession::AirPlay(s) => s.renderer.friendly_name.clone(),
+        }
+    }
+
+    pub fn ip(&self) -> IpAddr {
+        match self {
+            ActiveSession::Upnp(s) => s.renderer.ip,
+            ActiveSession::AirPlay(s) => s.renderer.ip,
+        }
+    }
+
+    /// Tear down — drops GENA subscription / RTSP connection /
+    /// background threads. Best-effort; receivers eventually time out
+    /// anyway, so failures here aren't fatal.
+    pub fn stop(self) {
+        match self {
+            ActiveSession::Upnp(s) => stop_session(&s),
+            ActiveSession::AirPlay(s) => s.stop(),
+        }
+    }
+
+    /// Push a volume change to the speaker. UPnP path goes via
+    /// SetVolume SOAP; AirPlay path goes via SET_PARAMETER over the
+    /// existing RTSP socket.
+    pub fn set_volume_pct(&self, pct: u32) -> Result<()> {
+        match self {
+            ActiveSession::Upnp(s) => {
+                upnp::set_volume(&s.renderer.rendering_control_control_url, pct)
+            }
+            ActiveSession::AirPlay(s) => s.set_volume_pct(pct),
+        }
+    }
+
+    /// Push a mute state to the speaker.
+    pub fn set_mute(&self, muted: bool) -> Result<()> {
+        match self {
+            ActiveSession::Upnp(s) => {
+                upnp::set_mute(&s.renderer.rendering_control_control_url, muted)
+            }
+            ActiveSession::AirPlay(s) => s.set_mute(muted),
+        }
+    }
+}
+
+pub type SharedSession = Arc<Mutex<Option<ActiveSession>>>;
 
 /// Stable summary of the runtime config that the GUI / tray can render.
 #[derive(Clone, Debug)]
@@ -65,6 +132,7 @@ pub struct App {
 
     // ---- Discovery + active session ----
     pub discovery: Option<Arc<DiscoveryState>>,
+    pub airplay_discovery: Option<Arc<AirPlayDiscoveryState>>,
     pub session: SharedSession,
     /// Remembered speaker id so Disable→Enable can rebind to the same one.
     pub last_speaker_id: Mutex<Option<String>>,
@@ -106,7 +174,11 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(config: AppConfig, discovery: Option<Arc<DiscoveryState>>) -> Arc<Self> {
+    pub fn new(
+        config: AppConfig,
+        discovery: Option<Arc<DiscoveryState>>,
+        airplay_discovery: Option<Arc<AirPlayDiscoveryState>>,
+    ) -> Arc<Self> {
         let web_initial = config.web_enabled;
         let user_config = UserConfig::load();
         // Seed last_speaker_id from disk so that, even before any user
@@ -116,6 +188,7 @@ impl App {
         Arc::new(Self {
             config,
             discovery,
+            airplay_discovery,
             session: Arc::new(Mutex::new(None)),
             last_speaker_id,
             hub: StreamHub::new(),
@@ -162,26 +235,68 @@ impl App {
     // -------------------------------------------------------------------
 
     /// Snapshot of discovered speakers and which one (if any) is active.
+    /// Merges the UPnP and AirPlay discovery lists; the GUI sees a
+    /// single sorted list with one row per speaker regardless of which
+    /// protocol it speaks.
     pub fn speaker_view(&self) -> SpeakerView {
-        let active_id = self.session.lock().unwrap().as_ref().map(|s| s.renderer.stable_id());
-        let speakers = match self.discovery.as_ref() {
-            None => Vec::new(),
-            Some(d) => d.renderers().into_iter().map(|r| {
+        let active_id = self.session.lock().unwrap().as_ref().map(|s| s.stable_id());
+        let mut speakers: Vec<SpeakerInfo> = Vec::new();
+
+        if let Some(d) = self.discovery.as_ref() {
+            for r in d.renderers() {
                 let id = r.stable_id();
                 let active = active_id.as_deref() == Some(id.as_str());
-                SpeakerInfo {
+                speakers.push(SpeakerInfo {
                     id,
                     friendly_name: r.friendly_name,
                     ip: r.ip.to_string(),
                     active,
-                }
-            }).collect(),
-        };
+                });
+            }
+        }
+        if let Some(d) = self.airplay_discovery.as_ref() {
+            for r in d.renderers() {
+                let id = r.stable_id();
+                let active = active_id.as_deref() == Some(id.as_str());
+                // Mark unsupported speakers (e.g. password-protected)
+                // with a parenthetical so the user can tell why
+                // selection might fail.
+                let name = if r.is_supported() {
+                    format!("{} (AirPlay)", r.friendly_name)
+                } else if r.password_protected {
+                    format!("{} (AirPlay, password-protected)", r.friendly_name)
+                } else {
+                    format!("{} (AirPlay, unsupported)", r.friendly_name)
+                };
+                speakers.push(SpeakerInfo {
+                    id,
+                    friendly_name: name,
+                    ip: r.ip.to_string(),
+                    active,
+                });
+            }
+        }
+        speakers.sort_by(|a, b| a.friendly_name.cmp(&b.friendly_name));
         SpeakerView { speakers, active_id }
     }
 
+    /// Returns the active UPnP renderer if the session is UPnP-flavoured.
+    /// Returns `None` for AirPlay sessions or no session — callers that
+    /// need the SOAP URL only work with UPnP anyway.
     pub fn current_renderer(&self) -> Option<Renderer> {
-        self.session.lock().unwrap().as_ref().map(|s| s.renderer.clone())
+        match self.session.lock().unwrap().as_ref() {
+            Some(ActiveSession::Upnp(s)) => Some(s.renderer.clone()),
+            _ => None,
+        }
+    }
+
+    /// Returns the active AirPlay renderer if the session is AirPlay-
+    /// flavoured. Mirror of `current_renderer` for the AirPlay path.
+    pub fn current_airplay_renderer(&self) -> Option<AirPlayRenderer> {
+        match self.session.lock().unwrap().as_ref() {
+            Some(ActiveSession::AirPlay(s)) => Some(s.renderer.clone()),
+            _ => None,
+        }
     }
 
     // -------------------------------------------------------------------
@@ -191,30 +306,25 @@ impl App {
     /// Switch to the speaker with the given stable id. Tears down any
     /// existing session, starts a new one. Remembers the id so Disable→
     /// Enable rebinds to the same speaker.
+    ///
+    /// Dispatches based on the id prefix:
+    ///   * `"airplay:<mac>"` → AirPlay RAOP session
+    ///   * anything else     → UPnP / OpenHome session
     pub fn select_speaker(&self, id: &str) -> Result<(), String> {
-        let discovery = self.discovery.as_ref()
-            .ok_or_else(|| "discovery disabled".to_string())?;
-        let Some(new_r) = discovery.find_by_id(id) else {
-            return Err(format!("no speaker with id {:?}", id));
+        let new_session = if id.starts_with("airplay:") {
+            self.start_airplay(id)?
+        } else {
+            self.start_upnp(id)?
         };
-        let didl = upnp::didl_lite_metadata(
-            &self.config.stream_uri,
-            PRODUCT_NAME,
-            self.config.initial_buffer_ms,
-        );
-        let new_session = start_session(
-            new_r,
-            &self.config.stream_uri,
-            &didl,
-            &self.config.callback_url,
-        ).map_err(|e| format!("{:#}", e))?;
+
         let mut guard = self.session.lock().unwrap();
         if let Some(old) = guard.take() {
             drop(guard);
-            stop_session(&old);
+            old.stop();
             guard = self.session.lock().unwrap();
         }
         *guard = Some(new_session);
+        drop(guard);
         *self.last_speaker_id.lock().unwrap() = Some(id.to_string());
         self.streaming_enabled.store(true, Ordering::Release);
         // Persist so the next launch can auto-reconnect to this speaker.
@@ -228,6 +338,59 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    fn start_upnp(&self, id: &str) -> Result<ActiveSession, String> {
+        let discovery = self
+            .discovery
+            .as_ref()
+            .ok_or_else(|| "UPnP discovery disabled".to_string())?;
+        let Some(new_r) = discovery.find_by_id(id) else {
+            return Err(format!("no UPnP speaker with id {:?}", id));
+        };
+        let didl = upnp::didl_lite_metadata(
+            &self.config.stream_uri,
+            PRODUCT_NAME,
+            self.config.initial_buffer_ms,
+        );
+        let session = start_session(
+            new_r,
+            &self.config.stream_uri,
+            &didl,
+            &self.config.callback_url,
+        )
+        .map_err(|e| format!("{:#}", e))?;
+        Ok(ActiveSession::Upnp(session))
+    }
+
+    fn start_airplay(&self, id: &str) -> Result<ActiveSession, String> {
+        let discovery = self
+            .airplay_discovery
+            .as_ref()
+            .ok_or_else(|| "AirPlay discovery disabled".to_string())?;
+        let Some(renderer) = discovery.find_by_id(id) else {
+            return Err(format!("no AirPlay speaker with id {:?}", id));
+        };
+
+        // Resolve a local IPv4 to bind UDP sockets to + advertise in
+        // SDP. Prefer the explicit `advertise_ip` (which the user can
+        // override). It must be reachable by the receiver, so falling
+        // back to a 0.0.0.0 here would be wrong.
+        let local_ip: IpAddr = self
+            .config
+            .advertise_ip
+            .parse()
+            .map_err(|e| format!("parsing advertise_ip {:?}: {}", self.config.advertise_ip, e))?;
+
+        let samples_rx = self.hub.subscribe();
+        let session = AirPlaySession::start(AirPlaySessionConfig {
+            renderer,
+            local_ip,
+            samples_rx,
+            initial_volume: Some(80),
+        })
+        .map_err(|e| format!("{:#}", e))?;
+        Ok(ActiveSession::AirPlay(session))
     }
 
     /// Fire a one-shot SSDP M-SEARCH on the same interface the periodic
@@ -255,16 +418,45 @@ impl App {
             .ok();
     }
 
-    /// Resync — UPnP Stop+Play on the current speaker. Drops Sonos's
-    /// accumulated prebuffer; next Play starts fresh with a minimal one.
+    /// Resync — drop the speaker's accumulated prebuffer.
+    ///
+    /// UPnP: Stop + Play, Sonos picks a fresh prebuffer level.
+    /// AirPlay: tear down and rebuild the session, which is the only
+    /// reliable way to flush RAOP's own jitter buffer (FLUSH is more
+    /// surgical but receivers differ on what it actually clears).
     pub fn resync(&self) -> Result<(), String> {
-        let r = self.current_renderer().ok_or_else(|| "no active speaker".to_string())?;
-        info!("resync: UPnP Stop + Play on {}", r.friendly_name);
-        if let Err(e) = upnp::stop(&r.av_transport_control_url) {
-            debug!("resync stop ignored: {}", e);
+        // Look at the active session under the lock briefly to figure
+        // out the dispatch, but don't hold the lock during the slow
+        // network calls.
+        enum Kind {
+            Upnp(Renderer),
+            AirPlay(String),
         }
-        std::thread::sleep(Duration::from_millis(100));
-        upnp::play(&r.av_transport_control_url).map_err(|e| format!("play failed: {:#}", e))
+        let kind = {
+            let guard = self.session.lock().unwrap();
+            match guard.as_ref() {
+                Some(ActiveSession::Upnp(s)) => Kind::Upnp(s.renderer.clone()),
+                Some(ActiveSession::AirPlay(s)) => {
+                    Kind::AirPlay(s.renderer.stable_id())
+                }
+                None => return Err("no active speaker".to_string()),
+            }
+        };
+        match kind {
+            Kind::Upnp(r) => {
+                info!("resync: UPnP Stop + Play on {}", r.friendly_name);
+                if let Err(e) = upnp::stop(&r.av_transport_control_url) {
+                    debug!("resync stop ignored: {}", e);
+                }
+                std::thread::sleep(Duration::from_millis(100));
+                upnp::play(&r.av_transport_control_url)
+                    .map_err(|e| format!("play failed: {:#}", e))
+            }
+            Kind::AirPlay(id) => {
+                info!("resync: AirPlay tear-down + reconnect for {}", id);
+                self.select_speaker(&id)
+            }
+        }
     }
 
     // -------------------------------------------------------------------
@@ -282,7 +474,7 @@ impl App {
         if !enabled {
             let s = self.session.lock().unwrap().take();
             if let Some(s) = s {
-                stop_session(&s);
+                s.stop();
             }
             info!("streaming disabled");
         } else {

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -4,6 +4,7 @@
 //! split exists so unit tests can exercise individual pieces (the silence
 //! detector in particular) without booting the whole service.
 
+pub mod airplay;
 pub mod app;
 pub mod audio_loop;
 pub mod audio_source;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use stream_to_speaker::airplay::{spawn_airplay_discovery, AirPlayDiscoveryState};
 use stream_to_speaker::app::{App, AppConfig};
 use stream_to_speaker::audio_source::AudioSource;
 use stream_to_speaker::gena::parse_rendering_notify;
@@ -126,6 +127,13 @@ struct Cli {
     /// Skip SSDP discovery; serve HTTP only.
     #[arg(long, default_value_t = false)]
     no_discovery: bool,
+
+    /// Skip AirPlay (mDNS) discovery. SSDP/UPnP is unaffected. Use
+    /// this if mDNS is noisy / blocked on the local network or if you
+    /// only ever stream to Sonos via UPnP and want to skip the
+    /// background browse traffic.
+    #[arg(long, default_value_t = false)]
+    no_airplay: bool,
 
     /// Disable silence injection (will send literal zeros during silence).
     #[arg(long, default_value_t = false)]
@@ -379,10 +387,10 @@ fn run_gui_mode(_app: Arc<App>, _no_tray: bool) -> Result<()> {
 }
 
 fn shutdown_cleanup(app: &Arc<App>) {
-    info!("shutdown: unsubscribing GENA");
+    info!("shutdown: tearing down active session");
     let final_session = app.session.lock().unwrap().take();
     if let Some(s) = final_session {
-        s.gena.unsubscribe();
+        s.stop();
     }
     info!("shutdown: complete");
 }
@@ -421,6 +429,18 @@ fn setup_app(cli: &Cli) -> Result<Arc<App>> {
         Some(state)
     };
 
+    let airplay_discovery = if cli.no_airplay {
+        None
+    } else {
+        let state = AirPlayDiscoveryState::new();
+        if let Err(e) = spawn_airplay_discovery(state.clone(), ssdp_iface) {
+            warn!("AirPlay discovery failed to start: {} (continuing without it)", e);
+            None
+        } else {
+            Some(state)
+        }
+    };
+
     let stream_uri = format!("http://{}:{}/stream.raw", advertise_ip, cli.port);
     let callback_url = format!("http://{}:{}/gena", advertise_ip, cli.port);
 
@@ -437,7 +457,7 @@ fn setup_app(cli: &Cli) -> Result<Arc<App>> {
         ssdp_iface,
     };
 
-    Ok(App::new(config, discovery))
+    Ok(App::new(config, discovery, airplay_discovery))
 }
 
 // -----------------------------------------------------------------------------
@@ -610,23 +630,23 @@ fn spawn_driver_event_consumer(app: Arc<App>, cli: &Cli) {
                     DriverEvent::VolumeChanged { level_millibels } => {
                         if let Some(level) = app.vsync.driver_changed(level_millibels) {
                             info!("driver -> speaker: volume {} (mb={})", level, level_millibels);
-                            if let Some(r) = app.current_renderer() {
-                                if let Err(e) = stream_to_speaker::upnp::set_volume(
-                                    &r.rendering_control_control_url,
-                                    level,
-                                ) {
-                                    warn!("upnp set_volume failed: {}", e);
+                            // Dispatch to whichever session kind is
+                            // active. The ActiveSession enum hides the
+                            // SOAP-vs-RTSP difference.
+                            let guard = app.session.lock().unwrap();
+                            if let Some(s) = guard.as_ref() {
+                                if let Err(e) = s.set_volume_pct(level) {
+                                    warn!("set_volume failed: {}", e);
                                 }
                             }
                         }
                     }
                     DriverEvent::MuteChanged { muted } => {
                         info!("driver -> speaker: mute={}", muted);
-                        if let Some(r) = app.current_renderer() {
-                            if let Err(e) =
-                                stream_to_speaker::upnp::set_mute(&r.rendering_control_control_url, muted)
-                            {
-                                warn!("upnp set_mute failed: {}", e);
+                        let guard = app.session.lock().unwrap();
+                        if let Some(s) = guard.as_ref() {
+                            if let Err(e) = s.set_mute(muted) {
+                                warn!("set_mute failed: {}", e);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Adds AirPlay 1 / RAOP sender support, parallel to the existing UPnP/OpenHome path. AirPlay receivers (AirPort Express, Sonos in AirPlay mode, shairport-sync, ...) appear in the same speaker picker — selecting one routes through a new `ActiveSession::AirPlay(...)` arm that runs the full RAOP wire protocol.

### What works

- **Discovery** — mDNS browse of `_raop._tcp.local.` via the pure-Rust `mdns-sd` crate (no Bonjour/mDNSResponder dependency, important for Windows shipping). Receivers appear in the existing GUI list with an "(AirPlay)" suffix.
- **RTSP handshake** — OPTIONS (with Apple-Challenge) → ANNOUNCE (with rsaaeskey + aesiv SDP attributes) → SETUP → RECORD → TEARDOWN. Uses the canonical iTunes 7.6 User-Agent (some Sonos firmwares gate on this).
- **Crypto** — 2048-bit Apple public RSA key (`et=1, vn=3` — the same key every shipping receiver decrypts) wrapping a fresh AES-128 session key, then AES-128-CBC encryption of the audio payload with the documented partial-block rule (encrypt `len & ~0xf`, leave trailing `len & 0xf` bytes as plaintext, IV reset per packet).
- **Audio path** — ALAC pass-through frames (uncompressed escape, 55-bit header + interleaved big-endian samples + 3-bit end tag = exactly 1416 bytes for 352 stereo samples), packetised into 12-byte RTP headers with PT=96, marker bit on first packet only, wall-clock-paced send loop.
- **Timing channel** — 32-byte timing responder echoing the NTP dance receivers send every few seconds.
- **Sync channel** — 1 Hz sync packet to the receiver's `control_port` with the current RTP timestamp anchor.
- **Volume** — RAOP `SET_PARAMETER` translating 0–100 % to dB (-30 .. 0, with -144 mute), driver volume push dispatches to whichever session type is active.

### Architecture

- New `airplay/` module: `discovery`, `rtsp`, `rtp`, `alac`, `crypto`, `timing`, `session`.
- New `ActiveSession::{Upnp, AirPlay}` enum on `App.session`, with uniform `stop()` / `set_volume_pct()` / `set_mute()` / `friendly_name()` / `stable_id()` so callers don't need to know which protocol they're driving.
- `App::select_speaker` dispatches on the `airplay:<mac>` id prefix.
- AirPlay sessions subscribe to the existing `StreamHub` — no new audio pipeline, just a new consumer.

### Out of scope (deliberate)

- **AirPlay 2 / HomeKit pairing** — HomePod and friends still won't work; they reject unpaired RTSP. Tracked as the next phase.
- **DACP callback channel** — receivers can't send remote-control events back to us yet. Not needed for basic playback.
- **Password-protected receivers** — marked as "(unsupported)" in the picker; HTTP-Digest auth left for follow-up.
- **`--player` matching for AirPlay in headless** — `--player <name>` still only matches UPnP. The GUI handles both.

### Verification

- `cargo test` — 18 tests pass, including ALAC frame layout (exactly 1416 bytes for stereo 352 samples), RSA key parses + produces 256-byte ciphertext, AES partial-block rule, RTP header byte layout.
- `cargo check` clean on Linux and `--target x86_64-pc-windows-gnu`.
- Real-device end-to-end testing requires a Windows host with the driver + an AirPlay receiver on the LAN — not testable from this Linux container.

## Test plan

- [ ] `cargo test` on Windows host
- [ ] Boot service, confirm AirPlay receiver appears in tray + GUI speaker list with "(AirPlay)" suffix
- [ ] Select an AirPort Express / shairport-sync receiver, confirm audio starts within ~1 s
- [ ] Volume slider on the speaker round-trips to the driver (driver → speaker direction)
- [ ] Hardware volume keys on the host adjust the AirPlay receiver
- [ ] Switching between a UPnP speaker and an AirPlay speaker tears down + brings up correctly
- [ ] `--no-airplay` flag disables AirPlay discovery
- [ ] Test on Sonos (AirPlay mode) and at least one shairport-sync receiver
---
