### PR TITLE
Fix the silent-no-window bug, ship the rest of the UI audit findings

### DIFF
--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -595,7 +595,24 @@ fn apply_theme(ctx: &egui::Context, dark: bool, system_accent: Option<(u8, u8, u
     visuals.widgets.noninteractive.rounding = RADIUS_CONTROL.into();
 
     // Inactive (button at rest)
-    visuals.widgets.inactive.bg_fill = p.card;
+    //
+    // `inactive.bg_fill` is ALSO the colour egui::Slider hard-codes
+    // for its rail (slider.rs:766 — `widget_visuals.inactive.bg_fill`,
+    // regardless of interact state). With bg_fill = p.card, the rail
+    // was painted card-on-card — completely invisible, leaving only
+    // the small outlined handle floating with no track to anchor
+    // against ("not displayed on an obvious axis"). Promoted to
+    // p.divider — already the colour used for card borders, so the
+    // rail reads as a structural line in the same vocabulary, and at
+    // ~3-ish-to-1 against the card it's plainly visible.
+    //
+    // Side-effect: DragValue's input background also picks this up
+    // (DragValue uses the inactive state's bg_fill for its at-rest
+    // surface). That actually reads better than card-on-card — looks
+    // like a real input field instead of an unbordered slot. Buttons
+    // are unaffected because our button helpers set `.fill(p.card)`
+    // explicitly on the egui::Button.
+    visuals.widgets.inactive.bg_fill = p.divider;
     visuals.widgets.inactive.weak_bg_fill = p.card;
     visuals.widgets.inactive.bg_stroke = egui::Stroke::new(1.0, p.divider);
     visuals.widgets.inactive.fg_stroke = egui::Stroke::new(1.0, p.text_primary);
@@ -640,6 +657,14 @@ fn apply_theme(ctx: &egui::Context, dark: bool, system_accent: Option<(u8, u8, u
     // 1-px subtle accent and rely on `selection.stroke` for the
     // focused widget on top.
     visuals.widgets.hovered.bg_stroke = egui::Stroke::new(1.0, p.accent);
+
+    // Slider visuals: fill the trailing portion of the rail (from
+    // min up to current value) with selection.bg_fill (= accent_subtle
+    // in our palette). Combined with the now-visible rail colour
+    // above, gives sliders a clear "track + progress + handle"
+    // structure — like Fluent / macOS sliders — instead of a
+    // disembodied circle floating with no axis.
+    visuals.slider_trailing_fill = true;
     ctx.set_visuals(visuals);
 
     let mut style = (*ctx.style()).clone();


### PR DESCRIPTION
## The bug behind "task manager shows it, no window"

The bug had three layers and ended up needing every one of them fixed:

1. **Deadlock in `select_speaker` (the real root cause).**  
   `select_speaker` held `self.session.lock()` in a `guard`, then later called `self.current_renderer()` — which re-locks `self.session`. `std::sync::Mutex` is not re-entrant, so the main thread blocked on its own lock forever. Audio loop, HTTP server, GENA bg threads kept running on their own threads (which is why the log showed "GENA subscribed", "speaker -> driver: volume 100", etc.). The process was alive, but `run()` never returned, `run_gui_mode()` never ran, `gui::run()` never started, no window ever painted.  
   Introduced in `d2e7a4f` (endpoint_name commit's first `current_renderer()` call) and `2aae0db` added a second deadlock point for the volume prime. Fixed by pulling the renderer out of the guard once and dropping the guard before any other lock-taking call.

2. **`persist_window: true` writing a hidden-window sentinel position.**  
   M28 turned on eframe's window persistence. The tray "minimise to tray" path uses raw Win32 `ShowWindow(SW_HIDE)` (we bypass `ViewportCommand::Visible` due to known queue-drain bugs — emilk/egui #5229, #3655). When eframe's shutdown captures `window.inner_position()` on a hidden window, Windows returns `(-32000, -32000)` — the sentinel for hidden/minimised windows. eframe persists that, restores it next launch, window is invisible. Now `persist_window: false`.

3. **No visibility into any of the above.**  
   With `windows_subsystem = "windows"`, panics and `Result::Err` returns vanish silently. Logging was initialised too late to catch failures before `env_logger.init()`. Now: panic hook with MessageBox + log file + backtrace, log init moved to the top of `main()`, startup tombstone file written before anything else, diagnostic markers at each gui-startup stage.

Defence in depth kept in place even though the deadlock fix is the actual cure:
- `rescue_offscreen_window`: re-centre on primary monitor if the rect ends up off all monitors.
- `force_show_normal`: always issue `ShowWindow(SW_SHOWNORMAL)` after eframe creates the HWND.
- Single-instance gate: duplicate launches raise the existing window instead of dying on the port bind.

## Rest of the PR — UI audit findings

| Done | What |
|---|---|
| m44 | Pinned compact status bar appears above the scroll once the full banner scrolls out |
| M8 / M9 / M12 / M13 / M14 | Padding tokens, banner stripe via post-paint, IP inset, header indent |
| M6 / M7 | Type ramp collapsed to 12/14/16/20 (+34 icon hero); `TextStyle::Heading` wired |
| M20 | Status icons unified to Media Control Symbols block (U+23F5–23F9) |
| M15 | Advanced numeric settings get Slider + DragValue side-by-side |
| m1 / m2 / m3 | Between-card 14→sp::M, onboarding circle alignment, spacing tokenisation |
| m4 / m5 | Theme-toggle hover halo killed; Advanced disclosure 28→32 px |
| m23 | Speaker-row friendly name elides with `…` instead of clipping through the IP |
| m24 | Speaker-side volume slider (reads/writes via existing `volume_sync` bridge) |
| m26 / m27 / m28 / m29 | WCAG contrast pass: warn, onboarding digit, button stroke, accent-on-white |
| — | Slider rails are now actually visible (rail painted `p.divider`, trailing fill in `accent_subtle`) |

Other shipped here:
- "Auto-connect on launch" preference, persisted to `user_config.json`, with a checkbox in the Speakers card.
- Windows endpoint name now reflects the active speaker — `Stream To Speaker → Living Room` in Sound Settings / volume mixer. Reverts on Forget.
- Installer prompts with an explicit "Close it for me" button (taskkill + mutex-release poll) instead of Inno's generic dialog.

Explicitly skipped (per discussion): m13 cumulative latency (none of the estimation paths were good enough), m19, m16, m43.

## Test plan
- [ ] Fresh install → window appears immediately.
- [ ] Install with prior version running → installer prompts, kills cleanly, new install launches with window.
- [ ] Launch twice → second launch raises the first window instead of dying on port bind.
- [ ] Close to tray → re-open via tray "Show window" → window comes back at the right place.
- [ ] Move window, close-to-tray, kill process, re-launch → window opens at default position (not off-screen).
- [ ] Sliders (volume + Advanced) have a visible track AND a visible filled-progress portion.
- [ ] Volume slider drag pushes to the speaker; speaker-side volume change reflects back in the slider.
- [ ] Endpoint name in Sound Settings updates when picking a speaker.
- [ ] "Auto-connect on launch" toggle persists across restarts.
---
