### PR TITLE
Fix three UX-review findings: tray enabled-state, rescan error surfacing, in-flight flag leak

### DIFF
--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -1546,7 +1546,7 @@ impl App {
     /// blocks for ~3 s waiting for responses; the GUI button doesn't
     /// want to freeze. Results land in `DiscoveryState::replace` and
     /// are picked up by the next `speaker_view()` call.
-    pub fn trigger_rescan(&self) {
+    pub fn trigger_rescan(self: &Arc<Self>) {
         let Some(discovery) = self.discovery.clone() else {
             warn!("trigger_rescan: discovery disabled");
             return;
@@ -1557,31 +1557,30 @@ impl App {
             return;
         }
         let iface = self.config.ssdp_iface;
-        let in_flight = self.rescan_in_flight.clone();
-        let last_finished = self.last_rescan_finished_unix.clone();
-        let last_count = self.last_rescan_count.clone();
+        let app = self.clone();
         std::thread::Builder::new()
             .name("stream-to-speaker-rescan".to_string())
             .spawn(move || {
-                let count = match crate::ssdp::discover_once(Duration::from_secs(3), iface) {
+                match crate::ssdp::discover_once(Duration::from_secs(3), iface) {
                     Ok(found) => {
                         let n = found.len();
                         info!("manual rescan: {} renderer(s) found", n);
                         discovery.replace(found);
-                        n
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs() as i64)
+                            .unwrap_or(0);
+                        app.last_rescan_count.store(n, Ordering::Release);
+                        app.last_rescan_finished_unix.store(now, Ordering::Release);
                     }
                     Err(e) => {
-                        warn!("manual rescan failed: {}", e);
-                        0
+                        // A failed scan is not "no speakers found" —
+                        // surface it as an error banner instead of the
+                        // scan-complete label.
+                        app.record_error(format!("Couldn't scan for speakers: {}", e));
                     }
-                };
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs() as i64)
-                    .unwrap_or(0);
-                last_count.store(count, Ordering::Release);
-                last_finished.store(now, Ordering::Release);
-                in_flight.store(false, Ordering::Release);
+                }
+                app.rescan_in_flight.store(false, Ordering::Release);
             })
             .ok();
     }

--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -1558,7 +1558,7 @@ impl App {
         }
         let iface = self.config.ssdp_iface;
         let app = self.clone();
-        std::thread::Builder::new()
+        let spawned = std::thread::Builder::new()
             .name("stream-to-speaker-rescan".to_string())
             .spawn(move || {
                 match crate::ssdp::discover_once(Duration::from_secs(3), iface) {
@@ -1581,8 +1581,14 @@ impl App {
                     }
                 }
                 app.rescan_in_flight.store(false, Ordering::Release);
-            })
-            .ok();
+            });
+        if let Err(e) = spawned {
+            // If the thread never started, nothing will clear the
+            // in-flight flag — reset it here or every later rescan
+            // would no-op at the swap guard above.
+            self.rescan_in_flight.store(false, Ordering::Release);
+            self.record_error(format!("Couldn't start speaker scan: {}", e));
+        }
     }
 
     /// Resync — drop the speaker's accumulated prebuffer.

--- a/service/src/tray.rs
+++ b/service/src/tray.rs
@@ -91,12 +91,17 @@ pub fn spawn(app: Arc<App>, egui_ctx: egui::Context) -> Result<TrayHandle> {
     // (previously the GUI used −/+ symbols and the tray used the
     // verbs, so the same action had two different labels across
     // surfaces — Content L2 from the audit).
+    // Speaker-dependent items start out matching the actual bound
+    // state, so a fresh launch with no speaker doesn't leave them
+    // enabled-but-no-op (pump() only syncs on *changes* to
+    // `last_speaker_bound`).
+    let speaker_bound = app.is_speaker_bound();
     let switch_speaker = MenuItem::new("Switch speaker…", true, None);
-    let trim_25 = MenuItem::new("Trim 25 ms (sync faster)", true, None);
-    let trim_100 = MenuItem::new("Trim 100 ms (sync faster)", true, None);
-    let pad_25 = MenuItem::new("Pad 25 ms (more buffer)", true, None);
-    let pad_100 = MenuItem::new("Pad 100 ms (more buffer)", true, None);
-    let resync = MenuItem::new("Resync speaker", true, None);
+    let trim_25 = MenuItem::new("Trim 25 ms (sync faster)", speaker_bound, None);
+    let trim_100 = MenuItem::new("Trim 100 ms (sync faster)", speaker_bound, None);
+    let pad_25 = MenuItem::new("Pad 25 ms (more buffer)", speaker_bound, None);
+    let pad_100 = MenuItem::new("Pad 100 ms (more buffer)", speaker_bound, None);
+    let resync = MenuItem::new("Resync speaker", speaker_bound, None);
     menu.append(&switch_speaker)?;
     menu.append(&trim_25)?;
     menu.append(&trim_100)?;
@@ -107,7 +112,7 @@ pub fn spawn(app: Arc<App>, egui_ctx: egui::Context) -> Result<TrayHandle> {
 
     let enable_toggle = CheckMenuItem::new(
         "Streaming enabled",
-        true,
+        speaker_bound,
         app.is_streaming_enabled(),
         None,
     );
@@ -196,7 +201,7 @@ pub fn spawn(app: Arc<App>, egui_ctx: egui::Context) -> Result<TrayHandle> {
         last_label: String::new(),
         last_enabled: app.is_streaming_enabled(),
         last_web_enabled: web_on,
-        last_speaker_bound: false,
+        last_speaker_bound: speaker_bound,
         hwnd,
     })
 }


### PR DESCRIPTION
Three bugs found in a code review of the shipped UX-polish work, each fixed minimally in its own commit.

## 1. Tray menu enabled-state never synced on fresh launch (`service/src/tray.rs`)

**Symptom:** On a fresh launch with no speaker bound, the speaker-dependent tray items (Trim/Pad ×4, Resync, the streaming enable-toggle) were clickable but silently no-oped — the exact behavior the original F-16 fix was supposed to remove.

**Cause:** The items were created with `enabled: true` while `last_speaker_bound` was initialized to `false`, and `pump()` only pushes enabled state when `speaker_bound != self.last_speaker_bound`. With no speaker bound, both sides were `false`, so the sync branch never fired.

**Fix:** Seed both the items' initial enabled state and `last_speaker_bound` from `app.is_speaker_bound()` at menu creation — the same pattern already used for `last_enabled` (`is_streaming_enabled`) and `last_web_enabled`.

## 2. Failed rescan reported "no speakers found" instead of an error (`service/src/app.rs`, `trigger_rescan`)

**Symptom:** If the one-shot SSDP discovery failed (socket/network error), the GUI showed "Scan complete — no speakers found", which reads as a successful empty scan.

**Cause:** The `Err` arm of `ssdp::discover_once` recorded `count = 0` plus a finished timestamp, feeding the scan-complete label.

**Fix:** Route the `Err` arm through `record_error` ("Couldn't scan for speakers: …"), which also logs it, and only store the count/timestamp on success. The in-flight flag is still cleared on both paths. `trigger_rescan` now takes `self: &Arc<Self>` (same receiver style as `resync`) so the detached thread can call `record_error`; both call sites already invoke it on an `Arc<App>`.

## 3. `rescan_in_flight` leaked if the thread failed to spawn (`service/src/app.rs`, `trigger_rescan`)

**Symptom:** If `thread::Builder::spawn` failed, the spinner ran forever and every later rescan silently no-oped.

**Cause:** The flag was set before spawning and the spawn `Result` was discarded with `.ok()`, so nothing ever cleared it.

**Fix:** Handle the spawn `Err` arm — `store(false, Ordering::Release)` on the flag and record an error banner ("Couldn't start speaker scan: …").

## Validation

`cargo check` in `service/` passes cleanly on the Linux dev box (the Windows-specific paths are cfg-gated, so this checks the touched code but not the `#[cfg(windows)]` branches — none of which were modified). No Windows machine was available for a full build/runtime test; the edits are minimal and match surrounding style.
