### PR TITLE
Private-repo signing: artifact-source mode + authenticated release fetches

### DIFF
--- a/.github/actions/request-signing/action.yml
+++ b/.github/actions/request-signing/action.yml
@@ -1,22 +1,49 @@
 name: Request EV code signature
 description: >
-  Dispatch the central signing workflow (Mihonarium/signing, sign.yml) for a
-  publicly downloadable file, wait for the human approval gate there and for
-  the run to finish, download the "signed" artifact, verify it locally with
-  signtool, and expose the signed file's path + hash. The approval in the
-  signing repo authorizes exactly the SHA-256 this action computes from the
-  bytes at artifact-url, so nothing can be swapped between dispatch and
-  signature. Windows runners only (pwsh + signtool from the preinstalled
-  Windows SDK). The calling job must run in the `request-signing`
-  environment so it can read the SIGNING_REPO_TOKEN secret.
+  Dispatch the central signing workflow (Mihonarium/signing, sign.yml), wait
+  for the human approval gate there and for the run to finish, download the
+  "signed" artifact, verify it locally with signtool, and expose the signed
+  file's path + hash. The approval in the signing repo authorizes exactly
+  the SHA-256 this action computes from the source bytes, so nothing can be
+  swapped between dispatch and signature. Two source modes:
+    - artifact-url: a URL fetchable WITHOUT authentication (public repos /
+      presigned URLs only — a private repo's release URLs serve a 404 page).
+    - source-run-id + source-artifact: an Actions artifact of a run in THIS
+      repository; the signing workflow fetches it post-approval with its
+      FETCH_TOKEN environment secret (fine-grained PAT, Actions: Read-only
+      on this repo). This is the mode that works from a private repo.
+  Windows runners only (pwsh + signtool from the preinstalled Windows SDK).
+  The calling job must run in the `request-signing` environment so it can
+  read the SIGNING_REPO_TOKEN secret.
 
 inputs:
   artifact-url:
     description: >
-      Public (unauthenticated) URL of the exact bytes to sign — e.g. a
-      release-asset download URL. The signing workflow fetches this itself,
-      so it must stay reachable until the human approves.
-    required: true
+      Source mode A: public (unauthenticated) URL of the exact bytes to
+      sign. The signing workflow fetches this itself, so it must stay
+      reachable until the human approves. Mutually exclusive with
+      source-run-id/source-artifact.
+    required: false
+    default: ""
+  source-run-id:
+    description: >
+      Source mode B (private repos): numeric Actions run ID in this
+      repository whose artifact holds the unsigned file (use github.run_id
+      to sign an artifact uploaded earlier in the same run). Requires
+      source-artifact; mutually exclusive with artifact-url.
+    required: false
+    default: ""
+  source-artifact:
+    description: "Source mode B: name of the Actions artifact (must contain exactly one file)"
+    required: false
+    default: ""
+  repo-token:
+    description: >
+      Token used to download the source artifact from this repository for
+      pre-dispatch hashing (mode B only). The default workflow token is
+      sufficient.
+    required: false
+    default: ${{ github.token }}
   output-name:
     description: >
       File name for the signed output (must satisfy the signing workflow's
@@ -80,6 +107,9 @@ runs:
       shell: pwsh
       env:
         REQSIGN_URL: ${{ inputs.artifact-url }}
+        REQSIGN_SRC_RUN: ${{ inputs.source-run-id }}
+        REQSIGN_SRC_ART: ${{ inputs.source-artifact }}
+        REQSIGN_REPO_TOKEN: ${{ inputs.repo-token }}
         REQSIGN_OUTPUT_NAME: ${{ inputs.output-name }}
         REQSIGN_SIG_DESCRIPTION: ${{ inputs.sig-description }}
         REQSIGN_SIG_URL: ${{ inputs.sig-url }}
@@ -101,7 +131,22 @@ runs:
         # Hash the actual bytes the signing workflow will fetch, not a local
         # copy — the approval over there binds to this digest.
         $unsigned = Join-Path $work "unsigned.bin"
-        Invoke-WebRequest -Uri $env:REQSIGN_URL -OutFile $unsigned
+        if ($env:REQSIGN_SRC_RUN) {
+            if ($env:REQSIGN_URL) { throw "give either artifact-url or source-run-id/source-artifact, not both" }
+            if (-not $env:REQSIGN_SRC_ART) { throw "source-artifact is required with source-run-id" }
+            if ($env:REQSIGN_SRC_RUN -notmatch '^\d+$') { throw "source-run-id must be numeric" }
+            $fetchDir = Join-Path $work "src-artifact"
+            $env:GH_TOKEN = $env:REQSIGN_REPO_TOKEN
+            gh run download $env:REQSIGN_SRC_RUN --repo $env:GITHUB_REPOSITORY `
+                --name $env:REQSIGN_SRC_ART --dir $fetchDir
+            if ($LASTEXITCODE -ne 0) { throw "gh run download failed for artifact '$($env:REQSIGN_SRC_ART)' of run $($env:REQSIGN_SRC_RUN)" }
+            $files = @(Get-ChildItem $fetchDir -Recurse -File)
+            if ($files.Count -ne 1) { throw "artifact '$($env:REQSIGN_SRC_ART)' must contain exactly one file, found $($files.Count)" }
+            Copy-Item $files[0].FullName $unsigned
+        } else {
+            if (-not $env:REQSIGN_URL) { throw "no source: set artifact-url, or source-run-id + source-artifact" }
+            Invoke-WebRequest -Uri $env:REQSIGN_URL -OutFile $unsigned
+        }
         $sha = (Get-FileHash $unsigned -Algorithm SHA256).Hash.ToLower()
         if ($env:REQSIGN_EXPECTED_SHA256 -and $env:REQSIGN_EXPECTED_SHA256.ToLower() -ne $sha) {
             throw "bytes at $env:REQSIGN_URL hash to $sha, expected $($env:REQSIGN_EXPECTED_SHA256.ToLower()) - refusing to request a signature for unexpected content"
@@ -109,15 +154,24 @@ runs:
         "unsigned-sha256=$sha" >> $env:GITHUB_OUTPUT
 
         # --- dispatch the signing workflow ---------------------------------
+        $dispatchInputs = @{
+            sha256          = $sha
+            output_name     = $env:REQSIGN_OUTPUT_NAME
+            sig_description = $env:REQSIGN_SIG_DESCRIPTION
+            sig_url         = $env:REQSIGN_SIG_URL
+        }
+        if ($env:REQSIGN_SRC_RUN) {
+            # Private-source mode: the signing workflow fetches the artifact
+            # post-approval with its FETCH_TOKEN environment secret.
+            $dispatchInputs.source_repo     = $env:GITHUB_REPOSITORY
+            $dispatchInputs.source_run_id   = $env:REQSIGN_SRC_RUN
+            $dispatchInputs.source_artifact = $env:REQSIGN_SRC_ART
+        } else {
+            $dispatchInputs.artifact_url = $env:REQSIGN_URL
+        }
         $body = @{
             ref = $env:REQSIGN_REF
-            inputs = @{
-                artifact_url    = $env:REQSIGN_URL
-                sha256          = $sha
-                output_name     = $env:REQSIGN_OUTPUT_NAME
-                sig_description = $env:REQSIGN_SIG_DESCRIPTION
-                sig_url         = $env:REQSIGN_SIG_URL
-            }
+            inputs = $dispatchInputs
         } | ConvertTo-Json
         Invoke-RestMethod -Method Post -Headers $hdr -Body $body -Uri `
             "https://api.github.com/repos/$($env:REQSIGN_REPO)/actions/workflows/$($env:REQSIGN_WORKFLOW)/dispatches"

--- a/.github/scripts/Get-AttestedDriver.ps1
+++ b/.github/scripts/Get-AttestedDriver.ps1
@@ -36,12 +36,14 @@ function Out-StepOutput([string]$line) {
     if ($env:GITHUB_OUTPUT) { $line >> $env:GITHUB_OUTPUT }
 }
 
-# Release assets can be served as application/octet-stream, in which case
-# Invoke-RestMethod would not parse the JSON — download then parse.
-function Get-JsonAsset([string]$url) {
+# Authenticated fetch via gh — unauthenticated release-asset URLs 404 on a
+# private repo (and assets can be served as octet-stream anyway, so we
+# download then parse rather than Invoke-RestMethod).
+function Get-JsonAsset([string]$tag, [string]$name) {
     $tmp = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString("N") + ".json")
     try {
-        Invoke-WebRequest -Uri $url -OutFile $tmp
+        gh release download $tag --repo $Repo --pattern $name --output $tmp --clobber
+        if ($LASTEXITCODE -ne 0) { throw "gh release download of $name from $tag failed" }
         Get-Content $tmp -Raw | ConvertFrom-Json
     } finally {
         Remove-Item $tmp -ErrorAction SilentlyContinue
@@ -56,7 +58,7 @@ foreach ($r in @($rels | Where-Object { $_.tag_name -like "driver-v*" -and -not 
     $manAsset = $r.assets | Where-Object { $_.name -eq "manifest.json" } | Select-Object -First 1
     if (-not $manAsset) { continue }
     try {
-        $m = Get-JsonAsset $manAsset.browser_download_url
+        $m = Get-JsonAsset $r.tag_name "manifest.json"
     } catch {
         Write-Host "  ($($r.tag_name): manifest fetch failed, skipping)"
         continue
@@ -82,7 +84,8 @@ if (-not $zipAsset) { throw "$($r.tag_name): manifest says attested=true but ass
 
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 $zipPath = Join-Path (Resolve-Path $OutDir).Path $m.signed_zip
-Invoke-WebRequest -Uri $zipAsset.browser_download_url -OutFile $zipPath
+gh release download $r.tag_name --repo $Repo --pattern $m.signed_zip --output $zipPath --clobber
+if ($LASTEXITCODE -ne 0) { throw "gh release download of $($m.signed_zip) failed" }
 $zipSha = (Get-FileHash $zipPath -Algorithm SHA256).Hash.ToLower()
 if ($zipSha -ne $m.signed_zip_sha256.ToLower()) {
     throw "$($m.signed_zip) hashes to $zipSha but the manifest records $($m.signed_zip_sha256) - refusing to use it"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -500,8 +500,10 @@ jobs:
   #     read the PAT nor dispatch signing requests; a plain repo secret
   #     would be readable by any workflow run in this repo.
   #   - Optionally add a tag ruleset restricting who can create v* tags.
-  #   - The signing workflow fetches artifact_url unauthenticated, so
-  #     this only works while our releases are public.
+  #   - Unsigned bytes travel to the signing repo as Actions artifacts
+  #     (private-source mode): the signing workflow fetches them
+  #     post-approval with its FETCH_TOKEN environment secret (fine-grained
+  #     PAT, Actions: Read-only on this repo). Works with this repo private.
   #
   # NB the step-summary hash table printed by the build job shows the DEV
   # (test-signed, unsigned-exe) artifacts; the .sha256 sidecars on the
@@ -510,8 +512,8 @@ jobs:
 
   # EV-sign the service exe first, so the released installer CONTAINS a
   # signed binary (better AV/firewall-prompt story than only signing the
-  # setup wrapper). The unsigned exe is briefly a public release asset —
-  # that's inherent to the signing repo's pull-by-URL model.
+  # setup wrapper). The unsigned exe travels as a workflow artifact; only
+  # the signed exe ever lands on the release.
   sign-service:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
@@ -530,7 +532,7 @@ jobs:
           name: release-inputs
           path: release-inputs
 
-      - name: Create release + upload unsigned service exe
+      - name: Create release + stage unsigned service exe
         id: upload
         shell: pwsh
         run: |
@@ -543,16 +545,26 @@ jobs:
               gh release create $tag --title $tag --generate-notes --verify-tag
               if ($LASTEXITCODE -ne 0) { throw "gh release create failed" }
           }
-          gh release upload $tag $name --clobber
-          if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }
           "name=$name" >> $env:GITHUB_OUTPUT
           "sha=$sha" >> $env:GITHUB_OUTPUT
+
+      # The unsigned exe travels to the signing repo as a workflow artifact
+      # (private-source mode) — it is never a release asset; only the signed
+      # exe lands on the release.
+      - name: Upload unsigned service exe as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-service-exe
+          path: ${{ steps.upload.outputs.name }}
+          if-no-files-found: error
+          retention-days: 3
 
       - name: Sign service exe via central signing workflow
         id: sign
         uses: ./.github/actions/request-signing
         with:
-          artifact-url: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.upload.outputs.name }}
+          source-run-id: ${{ github.run_id }}
+          source-artifact: unsigned-service-exe
           expected-sha256: ${{ steps.upload.outputs.sha }}
           output-name: ${{ steps.upload.outputs.name }}
           sig-description: "Stream To Speaker"
@@ -696,20 +708,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Locate the setup exe release asset
+      - name: Fetch setup exe from the release + stage for signing
         id: asset
         shell: pwsh
         run: |
-          $rel = gh api "repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" | ConvertFrom-Json
-          $assets = @($rel.assets | Where-Object { $_.name -like "StreamToSpeakerSetup-*.exe" })
-          if ($assets.Count -ne 1) { throw "expected exactly one setup exe asset on ${{ github.ref_name }}, found $($assets.Count)" }
-          "name=$($assets[0].name)" >> $env:GITHUB_OUTPUT
+          # Authenticated download — the repo is private, so the release
+          # asset URL is not fetchable by the signing workflow; the exe is
+          # re-exposed to it as a workflow artifact instead.
+          New-Item -ItemType Directory -Force -Path setup-unsigned | Out-Null
+          gh release download "${{ github.ref_name }}" --pattern "StreamToSpeakerSetup-*.exe" --dir setup-unsigned
+          if ($LASTEXITCODE -ne 0) { throw "gh release download failed" }
+          $exe = @(Get-ChildItem setup-unsigned -Filter "StreamToSpeakerSetup-*.exe")
+          if ($exe.Count -ne 1) { throw "expected exactly one setup exe asset on ${{ github.ref_name }}, found $($exe.Count)" }
+          "name=$($exe[0].Name)" >> $env:GITHUB_OUTPUT
+          "path=$($exe[0].FullName)" >> $env:GITHUB_OUTPUT
+
+      - name: Upload unsigned setup exe as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-setup-exe
+          path: ${{ steps.asset.outputs.path }}
+          if-no-files-found: error
+          retention-days: 3
 
       - name: Sign installer via central signing workflow
         id: sign
         uses: ./.github/actions/request-signing
         with:
-          artifact-url: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.asset.outputs.name }}
+          source-run-id: ${{ github.run_id }}
+          source-artifact: unsigned-setup-exe
           output-name: ${{ steps.asset.outputs.name }}
           sig-description: "Stream To Speaker Setup"
           token: ${{ secrets.SIGNING_REPO_TOKEN }}

--- a/.github/workflows/driver-attested.yml
+++ b/.github/workflows/driver-attested.yml
@@ -65,8 +65,10 @@ jobs:
                   $manAsset = $r.assets | Where-Object { $_.name -eq "manifest.json" } | Select-Object -First 1
                   if (-not $manAsset) { continue }
                   try {
-                      # Assets can be served as octet-stream; download + parse.
-                      Invoke-WebRequest -Uri $manAsset.browser_download_url -OutFile candidate-manifest.json
+                      # Authenticated fetch (private repo); assets can be
+                      # octet-stream, so download + parse.
+                      gh release download $r.tag_name --pattern manifest.json --output candidate-manifest.json --clobber
+                      if ($LASTEXITCODE -ne 0) { throw "gh release download failed" }
                       $m = Get-Content candidate-manifest.json -Raw | ConvertFrom-Json
                   } catch { continue }
                   if ($m.attested) { continue }

--- a/.github/workflows/driver-submission.yml
+++ b/.github/workflows/driver-submission.yml
@@ -260,6 +260,18 @@ jobs:
             "| Source hash | ``${{ steps.srchash.outputs.hash }}`` |"
           ) -join "`n" | Add-Content -Path $env:GITHUB_STEP_SUMMARY -Encoding utf8
 
+      # The signing hand-off uses this artifact (private-source mode — the
+      # repo is private, so release-asset URLs are not fetchable without
+      # auth); the release asset below is the durable record + what
+      # driver-attest.yml submits after it's EV-signed.
+      - name: Upload submission CAB as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: submission-cab
+          path: ${{ steps.cab.outputs.path }}
+          if-no-files-found: error
+          retention-days: 3
+
       - name: Create driver prerelease + upload submission CAB
         shell: pwsh
         env:
@@ -322,12 +334,16 @@ jobs:
               if ($r.tag_name -notmatch '^driver-v\d+\.\d+\.\d+\.(\d+)$') { continue }
               $build = [int]$Matches[1]
               if ($build -ge $current) { continue }
-              $keep = $false
+              # Default to KEEPING a release whose manifest we cannot read —
+              # a fetch failure must never look like "safe to delete" (on a
+              # private repo an unauthenticated fetch fails for every
+              # release, attested ones included).
+              $keep = $true
               $manAsset = $r.assets | Where-Object { $_.name -eq "manifest.json" } | Select-Object -First 1
               if ($manAsset) {
                   try {
-                      # Assets can be served as octet-stream; download + parse.
-                      Invoke-WebRequest -Uri $manAsset.browser_download_url -OutFile stale-manifest.json
+                      gh release download $r.tag_name --pattern manifest.json --output stale-manifest.json --clobber
+                      if ($LASTEXITCODE -ne 0) { throw "gh release download failed" }
                       $man = Get-Content stale-manifest.json -Raw | ConvertFrom-Json
                       # Keep attested releases (shipped driver history) AND
                       # releases with an in-flight Partner Center submission
@@ -370,7 +386,8 @@ jobs:
         id: sign
         uses: ./.github/actions/request-signing
         with:
-          artifact-url: https://github.com/${{ github.repository }}/releases/download/${{ needs.build-cab.outputs.tag }}/${{ needs.build-cab.outputs.cab_name }}
+          source-run-id: ${{ github.run_id }}
+          source-artifact: submission-cab
           expected-sha256: ${{ needs.build-cab.outputs.cab_sha256 }}
           output-name: ${{ needs.build-cab.outputs.cab_name }}
           sig-description: "Stream To Speaker driver attestation submission"
@@ -386,9 +403,10 @@ jobs:
           "$signedSha  $(Split-Path $signed -Leaf)" | Set-Content -Path "$signed.sha256" -Encoding ascii -NoNewline
 
           # Record the signed CAB's hash in the manifest so the exact bytes
-          # submitted to Microsoft stay identifiable.
-          $manUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/manifest.json"
-          Invoke-WebRequest -Uri $manUrl -OutFile manifest.json
+          # submitted to Microsoft stay identifiable. (Authenticated fetch —
+          # unauthenticated release URLs 404 on this private repo.)
+          gh release download $tag --pattern manifest.json --output manifest.json --clobber
+          if ($LASTEXITCODE -ne 0) { throw "gh release download of manifest.json failed" }
           $man = Get-Content manifest.json -Raw | ConvertFrom-Json
           $man.submission_cab_signed_sha256 = $signedSha
           $man | ConvertTo-Json | Set-Content -Path manifest.json -Encoding ascii

--- a/docs/driver-signing.md
+++ b/docs/driver-signing.md
@@ -78,9 +78,11 @@ release: `-testsigned` suffix + warning) until you run the loop again.
    (https://partner.microsoft.com/dashboard/hardware) and associate the
    Certum EV certificate with the account (the EV cert is both the
    registration credential and what must sign submission CABs).
-2. **Signing repo**: already set up per its README; no new secrets there —
-   this repo submits by public `artifact_url`, so `FETCH_TOKEN` is not
-   needed. Works only while this repo's releases are public.
+2. **Signing repo**: set up per its README, including the `FETCH_TOKEN`
+   environment secret (fine-grained PAT scoped to this repo, Actions:
+   Read-only). This repo is private, so unsigned bytes travel to the
+   signing workflow as Actions artifacts (its private-source mode) —
+   `FETCH_TOKEN` is how it fetches them, after your approval.
 3. **This repo — environment `request-signing`** (already exists for the
    installer signing): holds secret `SIGNING_REPO_TOKEN` (fine-grained PAT,
    scoped to only the signing repo, Actions Read+Write). **Add branch
@@ -166,9 +168,11 @@ Tag `vX.Y.Z` → `build.yml` runs the release chain:
 
 1. `build` — normal CI build; exports the service exe + driver-cache
    (test-signed fallback + devcon) to the release jobs.
-2. `sign-service` — creates the GitHub release (generated notes), uploads
-   `stream-to-speaker-<ver>.exe`, EV-signs it via the signing repo
-   (**approval click 1**), swaps in the signed exe + `.sha256`.
+2. `sign-service` — creates the GitHub release (generated notes), stages
+   `stream-to-speaker-<ver>.exe` as a workflow artifact, EV-signs it via
+   the signing repo (**approval click 1**), uploads the signed exe +
+   `.sha256` to the release (the unsigned exe never becomes a release
+   asset).
 3. `package` — fetches the attested driver matching this tag's driver
    source; stages it with the *signed* service exe (no test cert) and
    builds `StreamToSpeakerSetup-<ver>.exe`; attaches it plus the attested
@@ -183,9 +187,10 @@ Final release assets: signed `StreamToSpeakerSetup-<ver>.exe`, signed
 `stream-to-speaker-<ver>.exe`, `StreamToSpeaker-Driver-<dver>-Signed.zip`
 (Microsoft-signed driver package), and `.sha256` sidecars for each.
 
-The release is public from step 2 onward with in-progress assets (the
-pull-by-URL signing model requires it — same as the pre-existing installer
-signing). Don't announce until `sign-release` is green. If a job dies
+The release exists from step 2 onward with in-progress assets; unsigned
+bytes travel to the signing repo as Actions artifacts fetched with its
+`FETCH_TOKEN` (works with this repo private — nothing depends on public
+release URLs). Don't announce until `sign-release` is green. If a job dies
 mid-chain, re-run it: every step is idempotent (`--clobber` uploads,
 create-if-missing release). Re-running `package` after `sign-release` has
 finished overwrites the signed setup exe with an unsigned rebuild — re-run


### PR DESCRIPTION
The first live \`sign-cab\` run failed at its first step: this repo is **private**, and the signing hand-off assumed public release-asset URLs — the unauthenticated pre-dispatch download fetched GitHub's 404 page instead of the CAB. The signing workflow itself would have hit the same wall post-approval.

## Changes

**`request-signing` action — private-source mode.** New inputs `source-run-id` + `source-artifact`: the action downloads the Actions artifact with the workflow token to compute the approval-binding SHA-256, then dispatches the signing workflow's existing `source_repo`/`source_run_id`/`source_artifact` inputs, so the signing repo fetches the bytes post-approval with its `FETCH_TOKEN` environment secret (already provisioned). `artifact-url` mode remains for public/presigned sources. Provenance verification (signed output = submitted input + signature) unchanged.

**Call sites switched to artifact mode:** `sign-cab` (CAB uploaded as a `submission-cab` artifact), `sign-service` and `sign-release` (unsigned exes staged as artifacts — the unsigned bytes never become release assets anymore, which is also a small security win).

**Latent private-repo bugs fixed** (silent unauthenticated fetches):
- The stale-prerelease cleanup treated "couldn't read manifest" as "safe to delete" — on a private repo that would have deleted **attested** releases. It now defaults to keeping anything it can't read.
- `Get-AttestedDriver.ps1` would never find an attested driver (manifest fetch silently failed → installers permanently fall back to test-signed). All release-asset fetches now go through authenticated `gh release download`.

Docs updated; the "works only while releases are public" caveat is gone — nothing depends on public URLs now.

## After merge

Dispatch **Driver submission** (Actions tab) to restart the driver flow with the fixed hand-off — it rebuilds the CAB, dispatches signing, and after the one approval click the attestation chain runs end to end.
