### PR TITLE
Grant actions:read to signing jobs (artifact-mode 403 fix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -522,6 +522,7 @@ jobs:
     timeout-minutes: 75
     permissions:
       contents: write
+      actions: read              # gh run download of the unsigned-exe artifact
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -703,6 +704,7 @@ jobs:
     timeout-minutes: 75
     permissions:
       contents: write
+      actions: read              # gh run download of the unsigned-exe artifact
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/driver-submission.yml
+++ b/.github/workflows/driver-submission.yml
@@ -377,6 +377,7 @@ jobs:
     timeout-minutes: 150
     permissions:
       contents: write
+      actions: read              # gh run download of the submission-cab artifact
     env:
       GH_TOKEN: ${{ github.token }}
     steps:


### PR DESCRIPTION
First live sign-cab run in private-source mode failed with `HTTP 403: Resource not accessible by integration` on `gh run download`: the signing jobs declare a `permissions:` block (`contents: write`), which zeroes every other scope — including the `actions: read` that the artifact-download REST API requires. Adds `actions: read` to `sign-cab`, `sign-service`, and `sign-release` (the `package` job uses same-run `actions/download-artifact`, which doesn't need it).

After merge: dispatch **Driver submission** again.
