### PR TITLE
perf(ci): Defender exclusions before WDK cache restore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,24 @@ jobs:
       # workflow file (so this section can be iterated without poisoning
       # an old cache).
       # -----------------------------------------------------------------
+      # The WDK tree is ~50k small files; per-file Defender scanning is the
+      # dominant cost of the cache restore (measured: 293 s restore vs 67 s
+      # driver build). Excluding the target paths before extraction is a
+      # no-op if the image has real-time protection off — the step timing
+      # of "Restore WDK cache" is the measurement either way.
+      - name: Exclude WDK paths from Defender real-time scanning
+        shell: pwsh
+        run: |
+          try {
+              Add-MpPreference -ExclusionPath `
+                  "C:\Program Files (x86)\Windows Kits", `
+                  "C:\Program Files\Microsoft Visual Studio", `
+                  "C:\Program Files (x86)\Microsoft Visual Studio" -ErrorAction Stop
+              Write-Host "Defender exclusions added"
+          } catch {
+              Write-Host "Could not add Defender exclusions ($_) - continuing"
+          }
+
       - name: Restore WDK cache
         id: cache-wdk
         if: steps.cache-driver.outputs.cache-hit != 'true'

--- a/.github/workflows/driver-submission.yml
+++ b/.github/workflows/driver-submission.yml
@@ -85,6 +85,24 @@ jobs:
       # WDK. Restore-only: build.yml owns saving this cache; a miss here
       # just costs the ~5 min install.
       # ----------------------------------------------------------------
+      # The WDK tree is ~50k small files; per-file Defender scanning is the
+      # dominant cost of the cache restore (measured: 293 s restore vs 67 s
+      # driver build). Excluding the target paths before extraction is a
+      # no-op if the image has real-time protection off — the step timing
+      # of "Restore WDK cache" is the measurement either way.
+      - name: Exclude WDK paths from Defender real-time scanning
+        shell: pwsh
+        run: |
+          try {
+              Add-MpPreference -ExclusionPath `
+                  "C:\Program Files (x86)\Windows Kits", `
+                  "C:\Program Files\Microsoft Visual Studio", `
+                  "C:\Program Files (x86)\Microsoft Visual Studio" -ErrorAction Stop
+              Write-Host "Defender exclusions added"
+          } catch {
+              Write-Host "Could not add Defender exclusions ($_) - continuing"
+          }
+
       - name: Restore WDK cache
         id: cache-wdk
         uses: actions/cache/restore@v4


### PR DESCRIPTION
"Restore WDK cache" costs ~293 s for a 1.8 GB cache while the driver build itself is 67 s — the dominant cost is per-file Defender scanning of ~50k small files during tar extraction. This adds a Defender path exclusion for the Windows Kits + VS MSBuild trees immediately before the restore in both workflows. If the image already has real-time protection off, it's a no-op and the unchanged step timing will tell us; next escalation if this disappoints is a single-file VHDX cache (mount + junctions), which eliminates the small-file extraction entirely.

**Hold merging until the in-flight attestation run completes** — touching driver-submission.yml retriggers it.
