### PR TITLE
Pass --repo to gh release calls in the verify workflow

### DIFF
--- a/.github/workflows/driver-attested.yml
+++ b/.github/workflows/driver-attested.yml
@@ -67,7 +67,7 @@ jobs:
                   try {
                       # Authenticated fetch (private repo); assets can be
                       # octet-stream, so download + parse.
-                      gh release download $r.tag_name --pattern manifest.json --output candidate-manifest.json --clobber
+                      gh release download $r.tag_name --repo $repo --pattern manifest.json --output candidate-manifest.json --clobber
                       if ($LASTEXITCODE -ne 0) { throw "gh release download failed" }
                       $m = Get-Content candidate-manifest.json -Raw | ConvertFrom-Json
                   } catch { continue }
@@ -86,7 +86,7 @@ jobs:
           $version = $Matches[1]
 
           New-Item -ItemType Directory -Force -Path assets | Out-Null
-          gh release download $tag --dir assets
+          gh release download $tag --repo $repo --dir assets
           if ($LASTEXITCODE -ne 0) { throw "gh release download failed" }
           Get-ChildItem assets | ForEach-Object { Write-Host "  asset: $($_.Name)" }
 
@@ -186,9 +186,9 @@ jobs:
           $man | Add-Member -NotePropertyName ms_zip_asset -NotePropertyValue "${{ steps.rel.outputs.ms_zip_name }}" -Force
           $man | ConvertTo-Json | Set-Content -Path manifest.json -Encoding ascii
 
-          gh release upload $tag "${{ steps.verify.outputs.zip_name }}" "${{ steps.verify.outputs.zip_name }}.sha256" manifest.json --clobber
+          gh release upload $tag --repo "${{ github.repository }}" "${{ steps.verify.outputs.zip_name }}" "${{ steps.verify.outputs.zip_name }}.sha256" manifest.json --clobber
           if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }
-          gh release edit $tag --title "Driver $version — Microsoft-attested"
+          gh release edit $tag --repo "${{ github.repository }}" --title "Driver $version — Microsoft-attested"
           if ($LASTEXITCODE -ne 0) { throw "gh release edit failed" }
 
           @(


### PR DESCRIPTION
The attestation round-trip **worked**: run 31064387525's reconcile job created the Partner Center product + submission, uploaded the EV-signed CAB, polled, and attached `StreamToSpeaker-Driver-1.1.0.204-Microsoft.zip` to the release (`ms_state: done`).

The verify job then failed on plumbing: it runs without a checkout, so `gh release download` had no git remote to infer the repo from (`failed to run git: fatal: not a git repository`). Adds `--repo` to every `gh release` call there.

After merge, dispatching **Driver attested** with tag `driver-v1.1.0.204` finishes the round — no re-attestation needed, the signed zip is already on the release.
