### PR TITLE
Rewrite driver release notes on attestation

### DIFF
--- a/.github/workflows/driver-attested.yml
+++ b/.github/workflows/driver-attested.yml
@@ -188,7 +188,28 @@ jobs:
 
           gh release upload $tag --repo "${{ github.repository }}" "${{ steps.verify.outputs.zip_name }}" "${{ steps.verify.outputs.zip_name }}.sha256" manifest.json --clobber
           if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }
-          gh release edit $tag --repo "${{ github.repository }}" --title "Driver $version — Microsoft-attested"
+          # Replace the "awaiting attestation" runbook with what this
+          # release actually is now — the notes are what a human reads
+          # first, so a stale pending checklist on a finished release is
+          # actively misleading.
+          $notes = @(
+              "Microsoft-attested driver **$version** (commit $($man.commit))."
+              ""
+              "Install ``StreamToSpeaker-Driver-$version-Signed.zip`` on stock Windows 10 1809+ / Windows 11 — Secure Boot on, no test-signing mode. (Attestation-signed drivers do not load on Windows Server 2016+.)"
+              ""
+              "| | |"
+              "| --- | --- |"
+              "| Driver package | ``$($man.signed_zip)`` |"
+              "| SHA256 | ``$($man.signed_zip_sha256)`` |"
+              "| Driver source hash | ``$($man.source_hash)`` |"
+              "| Partner Center product / submission | ``$($man.ms_product_id)`` / ``$($man.ms_submission_id)`` |"
+              ""
+              "Verified in CI: ``signtool verify /kp`` against the catalog and the embedded ``.sys`` signature, signer chain *Microsoft Windows Hardware Compatibility Publisher*, INF byte-identical to the submitted one and carrying DriverVer $version."
+              ""
+              "Installer builds bundle this driver automatically while ``driver/**`` + ``include/**`` still hash to the source hash above. The other assets here are the submission trail: the EV-signed CAB sent to Microsoft, and the zip Microsoft returned."
+          ) -join "`n"
+          Set-Content -Path attested-notes.md -Value $notes -Encoding utf8
+          gh release edit $tag --repo "${{ github.repository }}" --title "Driver $version — Microsoft-attested" --notes-file attested-notes.md
           if ($LASTEXITCODE -ne 0) { throw "gh release edit failed" }
 
           @(


### PR DESCRIPTION
`driver-v1.1.0.204` is titled "Microsoft-attested" but its body still reads *"Status: awaiting Microsoft attestation"* with the pending runbook — a finished release looks like one still waiting on you.

The finalize step now replaces the notes with what the release actually is: which asset to install and on what (stock Win10 1809+/Win11, Secure Boot on; not Server), the package SHA-256, the driver source hash, the Partner Center product/submission IDs, and a line on what CI verified. The submission CAB and Microsoft's returned zip are described as the audit trail rather than left unexplained.

Kept as a **prerelease** on purpose: a non-prerelease `driver-v*` would become the repo's "Latest release" and bury the app installer.

After merge I'll re-run **Driver attested** for `driver-v1.1.0.204` to rewrite that release's notes in place (it's idempotent — re-verifies and re-uploads the same assets).
