### PR TITLE
Build-provenance attestations (armed for the public flip)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -607,10 +607,22 @@ jobs:
       # public. Verify with:
       #   gh attestation verify stream-to-speaker-<ver>.exe -R ${{ github.repository }}
       - name: Attest build provenance (public repo only)
+        id: attest
         if: ${{ !github.event.repository.private }}
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: ${{ steps.sign.outputs.signed-path }}
+
+      # Ship the Sigstore bundle beside the binary so anyone can verify
+      # offline (gh attestation verify --bundle) without querying GitHub.
+      - name: Publish the attestation bundle
+        if: ${{ !github.event.repository.private }}
+        shell: pwsh
+        run: |
+          $bundle = "$(Split-Path "${{ steps.sign.outputs.signed-path }}" -Leaf).sigstore.json"
+          Copy-Item "${{ steps.attest.outputs.bundle-path }}" $bundle
+          gh release upload "${{ github.ref_name }}" $bundle --clobber
+          if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }
 
   # Build the RELEASE installer: EV-signed service exe + the
   # Microsoft-attested driver package when one matches this tag's driver
@@ -788,7 +800,19 @@ jobs:
           Write-Host "Release asset replaced with the signed build (sha256 ${{ steps.sign.outputs.signed-sha256 }})"
 
       - name: Attest build provenance (public repo only)
+        id: attest
         if: ${{ !github.event.repository.private }}
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: ${{ steps.sign.outputs.signed-path }}
+
+      # Ship the Sigstore bundle beside the binary so anyone can verify
+      # offline (gh attestation verify --bundle) without querying GitHub.
+      - name: Publish the attestation bundle
+        if: ${{ !github.event.repository.private }}
+        shell: pwsh
+        run: |
+          $bundle = "$(Split-Path "${{ steps.sign.outputs.signed-path }}" -Leaf).sigstore.json"
+          Copy-Item "${{ steps.attest.outputs.bundle-path }}" $bundle
+          gh release upload "${{ github.ref_name }}" $bundle --clobber
+          if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -541,6 +541,8 @@ jobs:
     permissions:
       contents: write
       actions: read              # gh run download of the unsigned-exe artifact
+      id-token: write            # build-provenance attestation (public repo only)
+      attestations: write
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -597,6 +599,18 @@ jobs:
               Set-Content -Path "$signed.sha256" -Encoding ascii -NoNewline
           gh release upload "${{ github.ref_name }}" $signed "$signed.sha256" --clobber
           if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }
+
+      # Provenance for the exact bytes users download (post-signing, so the
+      # digest matches the release asset). No-op while the repo is private:
+      # attestations for private repos need GitHub Enterprise Cloud, so the
+      # step is gated on visibility and lights up the day the repo goes
+      # public. Verify with:
+      #   gh attestation verify stream-to-speaker-<ver>.exe -R ${{ github.repository }}
+      - name: Attest build provenance (public repo only)
+        if: ${{ !github.event.repository.private }}
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ steps.sign.outputs.signed-path }}
 
   # Build the RELEASE installer: EV-signed service exe + the
   # Microsoft-attested driver package when one matches this tag's driver
@@ -723,6 +737,8 @@ jobs:
     permissions:
       contents: write
       actions: read              # gh run download of the unsigned-exe artifact
+      id-token: write            # build-provenance attestation (public repo only)
+      attestations: write
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -770,3 +786,9 @@ jobs:
           gh release upload "${{ github.ref_name }}" $signed "$signed.sha256" --clobber
           if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }
           Write-Host "Release asset replaced with the signed build (sha256 ${{ steps.sign.outputs.signed-sha256 }})"
+
+      - name: Attest build provenance (public repo only)
+        if: ${{ !github.event.repository.private }}
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ steps.sign.outputs.signed-path }}

--- a/.github/workflows/driver-attested.yml
+++ b/.github/workflows/driver-attested.yml
@@ -36,6 +36,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write            # build-provenance attestation (public repo only)
+  attestations: write
 
 jobs:
   verify:
@@ -203,3 +205,14 @@ jobs:
             "Installer builds on main (and tag releases) now bundle this driver automatically"
             "as long as ``driver/**`` + ``include/**`` still hash to the manifest's source_hash."
           ) -join "`n" | Add-Content -Path $env:GITHUB_STEP_SUMMARY -Encoding utf8
+
+      # Provenance for the canonical driver package (bytes are final here).
+      # No-op while the repo is private — attestations on private repos
+      # need GitHub Enterprise Cloud; this lights up automatically the day
+      # the repo goes public. Verify with:
+      #   gh attestation verify StreamToSpeaker-Driver-<ver>-Signed.zip -R Mihonarium/StreamToSpeaker
+      - name: Attest build provenance (public repo only)
+        if: ${{ !github.event.repository.private }}
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ steps.verify.outputs.zip_name }}

--- a/.github/workflows/driver-attested.yml
+++ b/.github/workflows/driver-attested.yml
@@ -212,7 +212,21 @@ jobs:
       # the repo goes public. Verify with:
       #   gh attestation verify StreamToSpeaker-Driver-<ver>-Signed.zip -R Mihonarium/StreamToSpeaker
       - name: Attest build provenance (public repo only)
+        id: attest
         if: ${{ !github.event.repository.private }}
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: ${{ steps.verify.outputs.zip_name }}
+
+      # Ship the Sigstore bundle beside the package so anyone can verify
+      # offline (gh attestation verify --bundle) without querying GitHub.
+      - name: Publish the attestation bundle
+        if: ${{ !github.event.repository.private }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $bundle = "${{ steps.verify.outputs.zip_name }}.sigstore.json"
+          Copy-Item "${{ steps.attest.outputs.bundle-path }}" $bundle
+          gh release upload "${{ steps.rel.outputs.tag }}" --repo "${{ github.repository }}" $bundle --clobber
+          if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,32 @@ The virtual device shows up as **"Stream To Speaker"** in Windows Sound Settings
 
 Ships with a native GUI window plus a system-tray icon for quick controls — speaker picker, drain/pad latency buttons, enable/disable toggle, hard-resync. The headless CLI service is still there behind `--headless` for Windows-service installs.
 
+## Verifying your download
+
+Every released binary carries a GitHub build-provenance attestation: proof that
+these exact bytes came out of this repository's public workflow, at a specific
+commit — not from someone's laptop. The code-signing certificate says *who*
+published a file; the attestation says *what it was built from*.
+
+```
+gh attestation verify StreamToSpeakerSetup-<version>.exe -R Mihonarium/StreamToSpeaker
+```
+
+Verifying the installer covers everything inside it — service and driver alike
+are part of the attested bytes. Each release also ships the Sigstore bundle
+(`<file>.sigstore.json`) next to the binary, so you can verify offline:
+
+```
+gh attestation verify StreamToSpeakerSetup-<version>.exe \
+  --bundle StreamToSpeakerSetup-<version>.exe.sigstore.json \
+  -R Mihonarium/StreamToSpeaker
+```
+
+The kernel driver additionally carries Microsoft's attestation signature — it
+is submitted to the Partner Center hardware dashboard by CI and signed by the
+*Microsoft Windows Hardware Compatibility Publisher*, which is what lets it
+load on stock Windows with Secure Boot enabled.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
Adds `actions/attest-build-provenance@v3` for the three artifacts users will actually download — the signed service exe (`sign-service`), the signed installer (`sign-release`), and the canonical `-Signed.zip` driver package (`driver-attested` finalize) — each placed **after** signing, so the attested digest matches the published bytes.

All three steps are `if: !github.event.repository.private`: attestations on private repos require GitHub Enterprise Cloud, so they're no-ops today and switch on automatically the day the repo goes public, with no further changes. From then on anyone can verify:

```
gh attestation verify StreamToSpeakerSetup-<ver>.exe -R Mihonarium/StreamToSpeaker
```

(Provenance says "these exact bytes came out of this workflow at this commit" on Sigstore's public ledger — it complements the EV/Microsoft signatures, which say who published them.)
