### PR TITLE
Licensing split: MPL-2.0 source, all-rights-reserved binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,16 +693,12 @@ jobs:
           "$sha  ${{ steps.iscc.outputs.name }}" | Set-Content -Path "$exe.sha256" -Encoding ascii -NoNewline
           gh release upload $tag $exe "$exe.sha256" --clobber
           if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }
-          if ("${{ steps.attested.outputs.found }}" -eq "true") {
-              # Ship the attested driver package on the app release too so a
-              # manual/driver-only install doesn't need to hunt for the
-              # driver-v* prerelease.
-              $zip = "${{ steps.attested.outputs.zip }}"
-              $zsha = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
-              "$zsha  $(Split-Path $zip -Leaf)" | Set-Content -Path "$zip.sha256" -Encoding ascii -NoNewline
-              gh release upload $tag $zip "$zip.sha256" --clobber
-              if ($LASTEXITCODE -ne 0) { throw "gh release upload failed" }
-          }
+          # The attested driver package is deliberately NOT attached here.
+          # It ships inside the installer; publishing the signed .sys as a
+          # standalone asset hands anyone a Microsoft-signed virtual audio
+          # driver to drop into their own product (see LICENSE-BINARIES.md).
+          # The driver-v* prerelease keeps its copy — CI pairs installers to
+          # it by source hash, and that release is the audit trail.
           @(
             "## Release packaging"
             ""

--- a/LICENSE
+++ b/LICENSE
@@ -1,31 +1,373 @@
-MIT License
+Mozilla Public License Version 2.0
+==================================
 
-Copyright (c) 2026 Stream To Speaker contributors
+1. Definitions
+--------------
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
 
----
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
 
-This project incorporates code derived from:
+1.5. "Incompatible With Secondary Licenses"
+    means
 
-- Microsoft sysvad sample driver (MIT License)
-  https://github.com/microsoft/Windows-driver-samples
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
 
-- swyh-rs (MIT License)
-  https://github.com/dheijl/swyh-rs
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/LICENSE-BINARIES.md
+++ b/LICENSE-BINARIES.md
@@ -1,0 +1,56 @@
+# License for released binaries
+
+**Copyright © 2026 Stream To Speaker contributors. All rights reserved.**
+
+This notice covers the **compiled, signed artifacts published on this
+repository's releases** — the installer (`StreamToSpeakerSetup-*.exe`), the
+service executable (`stream-to-speaker-*.exe`), and the driver packages
+(`StreamToSpeaker-Driver-*-Signed.zip`, `*-Submission.cab`), including every
+file inside them.
+
+The **source code** is separately licensed under the Mozilla Public License
+2.0 — see [`LICENSE`](LICENSE). Nothing here limits or alters your rights to
+the source code under that license: you may read it, modify it, build your own
+binaries from it, and distribute those, subject only to the MPL.
+
+## Why these are licensed differently
+
+The published binaries carry two signatures that the source code cannot give
+you: an extended-validation code-signing certificate identifying us as the
+publisher, and — for the kernel driver — a Microsoft attestation signature
+obtained through the Windows Hardware Developer Program, which is what allows
+the driver to load on stock Windows with Secure Boot enabled. Those signatures
+represent an identity and a paid, audited process tied to us specifically.
+Redistributing the signed binaries would put our identity behind software we
+did not build and cannot vouch for, so the binaries themselves are not
+redistributable even though the code behind them is open.
+
+## What you may do
+
+- Download, install and use the binaries, for any purpose, personal or
+  commercial, on any number of machines.
+- Verify them — check the code signature, the Microsoft signature, and the
+  GitHub build-provenance attestation (see the README).
+- Link to the official release page.
+
+## What you may not do
+
+- Redistribute, mirror, re-host, bundle, or otherwise distribute the signed
+  binaries, in whole or in part, including inside another installer, package,
+  or product.
+- Modify the binaries, or strip, replace, or reuse any signature or catalog
+  file from them.
+- Use the driver binary or its catalog with software other than the
+  Stream To Speaker service it was built for.
+- Use the name "Stream To Speaker", or our logos, to identify your own builds
+  or products. Trademark rights are reserved and are not licensed by the MPL.
+
+**Want to distribute a build?** Build it from source under the MPL and sign it
+yourself. If you want to ship *our* signed binaries — bundled with a product,
+mirrored in a package manager, whatever — just ask; permission is often
+granted and always cheap to request.
+
+---
+
+*Plain-language summary, not a substitute for the text above: the code is
+open, our signatures are not.*

--- a/README.md
+++ b/README.md
@@ -294,4 +294,16 @@ L16 PCM, 44.1 kHz, stereo only. Wire MIME `audio/L16;rate=44100;channels=2` (we 
 
 ## License
 
-MIT. Driver scaffold derives from Microsoft's sysvad sample (MIT); service borrows UPnP/SSDP patterns from [swyh-rs](https://github.com/dheijl/swyh-rs) (MIT). Thanks to both projects.
+**Source: [MPL-2.0](LICENSE)** — use it, fork it, ship it inside proprietary
+software if you like; changes to *these files* come back to the commons.
+
+**Released binaries: [all rights reserved](LICENSE-BINARIES.md)** — install and
+use them freely, but don't redistribute or modify them. They carry our
+code-signing certificate and the driver's Microsoft attestation signature,
+which stand for our identity and a paid, audited process; the code behind them
+is open, our signatures are not. Want to ship a build? Build from source and
+sign it yourself, or ask us.
+
+Driver scaffold derives from Microsoft's sysvad sample (MIT); service borrows
+UPnP/SSDP patterns from [swyh-rs](https://github.com/dheijl/swyh-rs) (MIT).
+Thanks to both projects — their notices are retained in the files concerned.

--- a/docs/driver-signing.md
+++ b/docs/driver-signing.md
@@ -175,8 +175,11 @@ Tag `vX.Y.Z` → `build.yml` runs the release chain:
    asset).
 3. `package` — fetches the attested driver matching this tag's driver
    source; stages it with the *signed* service exe (no test cert) and
-   builds `StreamToSpeakerSetup-<ver>.exe`; attaches it plus the attested
-   driver zip to the release. If no attested driver matches, it falls back
+   builds `StreamToSpeakerSetup-<ver>.exe` and attaches it to the release.
+   The attested driver ships *inside* the installer and is deliberately not
+   published as a standalone asset (see `LICENSE-BINARIES.md`); the
+   `driver-v*` prerelease keeps the canonical copy. If no attested driver
+   matches, it falls back
    to the test-signed driver + cert and names the asset
    `StreamToSpeakerSetup-<ver>-testsigned.exe` with a warning — run Flow A,
    then re-tag, if you wanted a production release.
@@ -184,8 +187,8 @@ Tag `vX.Y.Z` → `build.yml` runs the release chain:
    it into the release. Its regenerated `.sha256` sidecar is canonical.
 
 Final release assets: signed `StreamToSpeakerSetup-<ver>.exe`, signed
-`stream-to-speaker-<ver>.exe`, `StreamToSpeaker-Driver-<dver>-Signed.zip`
-(Microsoft-signed driver package), and `.sha256` sidecars for each.
+`stream-to-speaker-<ver>.exe`, and `.sha256` sidecars for each (plus
+`.sigstore.json` provenance bundles once the repo is public).
 
 The release exists from step 2 onward with in-progress assets; unsigned
 bytes travel to the signing repo as Actions artifacts fetched with its


### PR DESCRIPTION
Prep for going public, aimed at the actual concern: not attackers, but someone lifting the **Microsoft attestation-signed driver** into their own product. They can't modify it (that breaks the signature), so what protects it is availability and licensing rather than code.

## Source → MPL-2.0

"Permissive share-alike": file-level copyleft, so modifications to these files come back, but the code can still be combined with proprietary software (unlike GPL, which would also be awkward for a kernel driver). MIT permits the relicense, the repo has never been public so there's no expectation to break, and the sysvad / swyh-rs attributions stay in place.

## Binaries → all rights reserved (`LICENSE-BINARIES.md`)

Install and use freely, commercially or not; no redistribution, no modification, no reusing the signatures or the driver with other software; trademark reserved. It **explicitly preserves every MPL right to the source** — build your own and ship it, just sign it yourself — which is both correct and what MPL §3.3 requires. Ends with an invitation to ask for permission, since the goal is to stop silent reuse, not collaboration.

## Stops publishing the standalone driver zip

App releases no longer attach `StreamToSpeaker-Driver-*-Signed.zip`; it ships inside the installer. The `driver-v*` prerelease keeps the canonical copy because CI pairs installers to it by source hash and it's the audit trail.

Worth a lawyer's eye on `LICENSE-BINARIES.md` before the repo flips public — I've written it to be clear and enforceable-sounding, but I'm not one.
