### PR TITLE
Donation banner with 7-day snooze

### DIFF
--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -386,6 +386,30 @@ impl App {
         }
     }
 
+    /// Whether to show the donation prompt: hidden until the stored
+    /// deadline passes. Shown on first launch (no stored value).
+    pub fn should_show_donation_prompt(&self) -> bool {
+        let uc = self.user_config.lock().unwrap();
+        // Never ask someone who hasn't got it working yet: no saved
+        // speaker means they are still setting up (or it failed for
+        // them), and a donation strip above the onboarding card would
+        // be asking for money before delivering anything.
+        if uc.last_speaker_id.is_none() {
+            return false;
+        }
+        match uc.donation_prompt_hidden_until {
+            None => true,
+            Some(t) => now_unix() >= t,
+        }
+    }
+
+    /// Hide the donation prompt for `days`, persisted immediately.
+    pub fn snooze_donation_prompt(&self, days: u64) {
+        let mut uc = self.user_config.lock().unwrap();
+        uc.donation_prompt_hidden_until = Some(now_unix() + days * 24 * 60 * 60);
+        uc.save();
+    }
+
     /// Undo the onboarding dismissal (Help menu → "Show getting-
     /// started again"). Persists immediately.
     pub fn reset_onboarding(&self) {
@@ -1832,3 +1856,12 @@ pub fn pick_ssdp_iface(advertise_ip: Option<&str>, bind: &str) -> Option<std::ne
 
 #[allow(dead_code)]
 const _: u32 = DEFAULT_QUIESCENT_AFTER_PACKETS;
+
+/// Seconds since the Unix epoch, saturating to 0 if the system clock is
+/// before 1970 (which would only happen on a badly misconfigured box).
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -1932,7 +1932,7 @@ impl StreamToSpeakerApp {
                         ui.label(
                             egui::RichText::new(
                                 "Stream To Speaker is free and open source. \
-                                 If it's useful, you can support its development.",
+                                 Donate to support its development.",
                             )
                             .color(p.text_on_accent_subtle),
                         );
@@ -1946,8 +1946,8 @@ impl StreamToSpeakerApp {
                             {
                                 self.app.snooze_donation_prompt(7);
                             }
-                            if primary_button(ui, p, "Buy me a coffee", 132.0)
-                                .on_hover_text("Opens buymeacoffee.com/ms00 in your browser.")
+                            if primary_button(ui, p, "Donate", 96.0)
+                                .on_hover_text("Opens buymeacoffee.com/ms00 in your browser. Any amount, one-off or monthly.")
                                 .clicked()
                             {
                                 let _ = open_url("https://buymeacoffee.com/ms00");

--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -1224,6 +1224,7 @@ impl eframe::App for StreamToSpeakerApp {
                             self.show_status_banner(ui, &p);
                             banner_bottom_px = ui.cursor().top();
                             self.show_error_banner(ui, &p);
+                            self.show_donation_banner(ui, &p);
                             ui.add_space(sp::M);
                             // Show onboarding regardless of whether a
                             // speaker is currently bound, until the
@@ -1900,6 +1901,61 @@ impl StreamToSpeakerApp {
                         |ui| {
                             if link_button(ui, p, "Dismiss", 80.0).clicked() {
                                 self.app.dismiss_error();
+                            }
+                        },
+                    );
+                });
+            });
+    }
+
+    /// Donation ask. Shown on launch until the user either follows the
+    /// link or asks to be reminded later; both choices persist, so it is
+    /// never the same nag twice in one week. Deliberately a quiet strip
+    /// rather than a modal — it must never stand between the user and
+    /// the speaker list.
+    fn show_donation_banner(&mut self, ui: &mut egui::Ui, p: &Palette) {
+        if !self.app.should_show_donation_prompt() {
+            return;
+        }
+        ui.add_space(sp::XS);
+        egui::Frame::none()
+            .fill(p.accent_subtle)
+            .rounding(RADIUS_SURFACE)
+            .inner_margin(egui::Margin::symmetric(sp::M, sp::S))
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new("☕").size(15.0),
+                    );
+                    ui.add_space(sp::XS);
+                    ui.vertical(|ui| {
+                        ui.label(
+                            egui::RichText::new(
+                                "Stream To Speaker is free and open source. \
+                                 If it's useful, you can support its development.",
+                            )
+                            .color(p.text_on_accent_subtle),
+                        );
+                    });
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            if secondary_button(ui, p, "Not now", 84.0)
+                                .on_hover_text("Hide this for a week.")
+                                .clicked()
+                            {
+                                self.app.snooze_donation_prompt(7);
+                            }
+                            if primary_button(ui, p, "Buy me a coffee", 132.0)
+                                .on_hover_text("Opens buymeacoffee.com/ms00 in your browser.")
+                                .clicked()
+                            {
+                                let _ = open_url("https://buymeacoffee.com/ms00");
+                                // We can't tell whether a donation actually
+                                // happened, so anyone who clicks through is
+                                // left alone for a year rather than asked
+                                // again next week.
+                                self.app.snooze_donation_prompt(365);
                             }
                         },
                     );

--- a/service/src/user_config.rs
+++ b/service/src/user_config.rs
@@ -29,6 +29,14 @@ pub struct UserConfig {
     /// preference into the same store.
     #[serde(default)]
     pub always_minimise_to_tray: bool,
+    /// Unix seconds until which the donation prompt stays hidden.
+    /// `None` = never shown yet (show it). Set 7 days out by "Remind me
+    /// later", and far out once the user has followed the donate link —
+    /// we can't know whether they actually donated, so the honest
+    /// assumption is that anyone who clicked through shouldn't be asked
+    /// again for a long while.
+    #[serde(default)]
+    pub donation_prompt_hidden_until: Option<u64>,
     /// Whether to auto-reconnect to `last_speaker_id` on launch.
     /// `true` (default) preserves the prior behaviour. `false` lets
     /// a user keep their saved speaker remembered (so the GUI knows


### PR DESCRIPTION
A quiet strip at the top of the window on launch:

- **Buy me a coffee** → opens `https://buymeacoffee.com/ms00`, then hides the strip for a year (we can't detect an actual donation, and re-asking a donor next week would be worse than not asking at all).
- **Not now** → hides it for 7 days.

Both persist via `user_config` (`donation_prompt_hidden_until`), so it's never the same nag twice in a week.

Two restraints worth calling out, since they weren't in the ask but seemed right: it's a strip rather than a modal, so it never stands between the user and the speaker list; and it stays hidden until `last_speaker_id` is set — i.e. until the user has actually got a speaker working — so nobody is asked for money before the app has done anything for them, and it can't stack on top of the onboarding card. Easy to drop either if you'd rather ask everyone from first launch.

**Not compile-verified here**: `gui.rs` is `#[cfg(windows)]`, so `cargo check` on Linux skips it — `app.rs` and `user_config.rs` do compile clean. The layout mirrors the existing error banner's proven structure (frame → horizontal → icon, wrapped label, right-aligned buttons) and uses only existing helpers (`primary_button`, `secondary_button`, `open_url`, `p.accent_subtle`, `p.text_on_accent_subtle`), but CI's build is the real check.
