### PR TITLE
Audio not working? Resync — in the status banner

### DIFF
--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -1745,19 +1745,66 @@ impl StreamToSpeakerApp {
                         ui.with_layout(
                             egui::Layout::right_to_left(egui::Align::Center),
                             |ui| {
-                                let r = if label == "Enable streaming" {
-                                    primary_button(ui, p, label, 140.0)
-                                } else {
-                                    secondary_button(ui, p, label, 140.0)
-                                }
-                                .on_hover_text(tip);
-                                if r.clicked() {
-                                    if let Err(e) = self.app.set_streaming_enabled(!enabled) {
-                                        self.app.record_error(
-                                            format!("Couldn't change streaming state: {}", e),
+                                ui.vertical(|ui| {
+                                    ui.with_layout(
+                                        egui::Layout::right_to_left(egui::Align::Center),
+                                        |ui| {
+                                            let r = if label == "Enable streaming" {
+                                                primary_button(ui, p, label, 140.0)
+                                            } else {
+                                                secondary_button(ui, p, label, 140.0)
+                                            }
+                                            .on_hover_text(tip);
+                                            if r.clicked() {
+                                                if let Err(e) =
+                                                    self.app.set_streaming_enabled(!enabled)
+                                                {
+                                                    self.app.record_error(format!(
+                                                        "Couldn't change streaming state: {}",
+                                                        e
+                                                    ));
+                                                }
+                                            }
+                                        },
+                                    );
+                                    // First-aid affordance. Resync is the fix
+                                    // for the most common complaint ("it says
+                                    // streaming but I hear nothing"), and it
+                                    // used to live only in Advanced and the
+                                    // tray menu — the two places a confused
+                                    // user is least likely to look. Only shown
+                                    // while streaming is enabled: with it off,
+                                    // silence is expected and Enable is the
+                                    // answer, not a resync.
+                                    if enabled {
+                                        ui.add_space(sp::XS);
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::Center),
+                                            |ui| {
+                                                if link_button(ui, p, "Resync", 72.0)
+                                                    .on_hover_text(
+                                                        "Stop and restart the speaker session. \
+                                                         Causes a brief click but clears silence, \
+                                                         stutter or drift. (Ctrl+Shift+R)",
+                                                    )
+                                                    .clicked()
+                                                {
+                                                    if let Err(e) = self.app.resync() {
+                                                        self.app.record_error(format!(
+                                                            "Resync failed: {}",
+                                                            e
+                                                        ));
+                                                    }
+                                                }
+                                                ui.label(
+                                                    egui::RichText::new("Audio not working?")
+                                                        .size(11.0)
+                                                        .color(p.text_secondary),
+                                                );
+                                            },
                                         );
                                     }
-                                }
+                                });
                             },
                         );
                     }


### PR DESCRIPTION
Puts the resync action where the problem is noticed: right of the status panel, under the enable/disable button, labelled with the question users actually have.

Resync is the fix for the most common failure report — banner says *Streaming to X*, nothing comes out — but it was only reachable from Advanced and the tray menu, the two places a confused user is least likely to look. Hidden while streaming is disabled, since silence is expected there and **Enable** is the right answer.

Same call and error handling as the existing Advanced button (`app.resync()`, failures surfaced through the error banner), and Ctrl+Shift+R still works.

**Not compile-verified here** — `gui.rs` is `#[cfg(windows)]`, so `cargo check` on Linux skips it; CI's build is the check. The layout nests inside the banner's existing right-aligned block and uses only existing helpers.
