### PR TITLE
README: one line per flag, tuning notes to TECHNICAL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,57 +32,42 @@ Closing the window minimises to the tray; quit from the tray menu.
 ## CLI flags
 
 ```
---headless                Disable the GUI; run as a CLI service.
---no-tray                 GUI window only, no system-tray icon.
---web                     Enable the HTTP/JSON API + web UI at the bound port.
-                          Off by default — when off, only /stream.raw is served.
+--headless                No GUI; run as a CLI service.
+--no-tray                 GUI window only, no tray icon.
+--web                     Enable the HTTP/JSON API + web UI. Off by default;
+                          when off, only /stream.raw is served.
 
 --source <auto|driver|wasapi-loopback|sine>
-                          Audio input. Default 'auto' tries the kernel driver,
-                          falls back to WASAPI loopback (cpal) if not present.
+                          Audio input. Default 'auto': kernel driver, falling
+                          back to WASAPI loopback.
 
---player <name-or-ip>     Speaker target. Substring match against friendly
-                          name, or an IPv4 literal. Omit to use the GUI picker
-                          (or the interactive terminal picker in --headless).
---no-interactive          Skip the terminal picker even in a TTY (Windows-service mode).
+--player <name-or-ip>     Speaker to use: name substring or IPv4. Omit to pick
+                          in the GUI (or the terminal picker in --headless).
+--no-interactive          Skip the terminal picker even in a TTY.
 --list-speakers           Print discovered speakers and exit.
---no-discovery            Skip SSDP entirely; only serve HTTP.
+--no-discovery            Skip discovery; only serve HTTP.
 
---port <N>                TCP port for /stream.raw and (if --web) the API. Default 5901.
+--port <N>                TCP port. Default 5901.
 --bind <ip>               HTTP bind address. Default 0.0.0.0.
---advertise-ip <ip>       What IP to put in the stream URI we send to the
-                          speaker. Defaults to the first non-loopback IPv4.
+--advertise-ip <ip>       IP to advertise in the stream URI sent to the
+                          speaker. Default: first non-loopback IPv4.
 
---initial-buffer-ms <N>   DIDL prebuffer hint sent to the speaker (default 50).
-                          Sonos generally ignores this; tune via the runtime
-                          adjust knobs instead.
-
---silence-pace-ms <N>     Wall-clock ms between silence packets while the
-                          Windows audio engine is paused. Default 10
-                          (= real-time). Higher = under-produces during
-                          silence, draining the speaker's prebuffer between
-                          tracks so post-pause latency is smaller.
-                          Useful range 12-25; >30 risks underrun.
-
---rate-fudge-ppm <N>      Steady-state clock-skew compensation. See above.
-                          Default 0 (no compensation).
-
+--initial-buffer-ms <N>   Prebuffer hint sent to the speaker. Default 50.
+--silence-pace-ms <N>     Pacing of silence packets. Default 10 (real-time);
+                          higher drains the speaker's buffer between tracks.
+--rate-fudge-ppm <N>      Clock-skew compensation. Default 0.
 --latency-adjust-step-frames <N>
-                          Maximum frames added/dropped per audio packet when
-                          servicing a /api/latency/adjust request. Default 4
-                          (≈ 0.09 ms per packet). Higher = snappier adjusts
-                          at the cost of more audible clicks.
-
---no-silence-injection    Don't replace silent packets with a low-noise floor.
-                          Default: inject ~|4|-peak white noise after 500 ms
-                          of silence so Sonos doesn't decide the stream died
-                          and disconnect.
+                          Frames added or dropped per packet while adjusting
+                          latency. Default 4.
+--no-silence-injection    Don't inject a low noise floor during silence.
 --silence-packets-threshold <N>
-                          Consecutive silent packets before quiescence kicks in.
+                          Consecutive silent packets before quiescence.
 
---ssdp-interval <N>       Minutes between SSDP re-discoveries. Default 5.
+--ssdp-interval <N>       Minutes between re-discoveries. Default 5.
 --log-level <level>       error / warn / info / debug / trace. Default info.
 ```
+
+Tuning the last group: [TECHNICAL.md](TECHNICAL.md#latency-control).
 
 ## Verifying a download
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -138,6 +138,22 @@ For *ongoing* drift between the Windows clock and the speaker's audio crystal (t
 - Negative drops a frame at the same rate — for the opposite case (rare).
 - Start with `0`, watch the buffer for a few minutes, and tune. The right value is whatever keeps Sonos's buffer level stable instead of slowly draining or growing.
 
+### Tuning notes
+
+- `--initial-buffer-ms` is a DIDL prebuffer hint; Sonos generally ignores it,
+  so prefer the runtime adjust knobs above.
+- `--silence-pace-ms` is wall-clock ms between silence packets while the
+  Windows audio engine is paused. Default 10 = real-time; higher values
+  under-produce during silence, draining the speaker's prebuffer between
+  tracks so post-pause latency is smaller. Useful range 12-25; above 30 risks
+  underrun.
+- `--latency-adjust-step-frames` caps frames added or dropped per audio packet
+  when servicing `/api/latency/adjust`. Default 4 (≈0.09 ms per packet);
+  higher is snappier at the cost of audible clicks.
+- Silence injection (on by default, disable with `--no-silence-injection`)
+  replaces silent packets with ~|4|-peak white noise after 500 ms of silence,
+  so the speaker doesn't decide the stream died and disconnect.
+
 ## CLI flags
 
 Listed in the [README](README.md#cli-flags).


### PR DESCRIPTION
Line-by-line pass over the flags block. Every flag stays; the paragraph-length tuning essays move to a Tuning notes subsection under Latency control in TECHNICAL.md, where the surrounding context already lives.

Fixes a broken cross-reference: `--rate-fudge-ppm` said "See above", but the latency section it referred to moved out of the README during the split.
