### PR TITLE
Installer: show combined binary + MPL license on the wizard's license page

### DIFF
--- a/installer/LICENSE-INSTALLER.txt
+++ b/installer/LICENSE-INSTALLER.txt
@@ -1,0 +1,50 @@
+Stream To Speaker - License
+===========================
+
+Two sets of terms apply: one to the signed program files this installer
+puts on your machine, and one to the source code they were built from.
+
+
+THE INSTALLED PROGRAM FILES
+
+Copyright (c) 2026 Stream To Speaker contributors. All rights reserved.
+
+You may install and use Stream To Speaker freely - for any purpose,
+personal or commercial, on any number of machines.
+
+You may not redistribute the installer or the installed files (mirror,
+re-host, or bundle them into another installer, package, or product),
+and you may not modify them or reuse their signatures or catalog files.
+That is because they carry our code-signing certificate and a Microsoft
+attestation signature for the kernel driver; those signatures identify
+us, so they only belong on builds we made. Full terms:
+https://github.com/Mihonarium/StreamToSpeaker/blob/main/LICENSE-BINARIES.md
+
+The name "Stream To Speaker" and our logos are reserved; do not use
+them to identify your own builds or products.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND. TO THE
+MAXIMUM EXTENT PERMITTED BY LAW, THE AUTHORS ACCEPT NO LIABILITY FOR
+ANY DAMAGES ARISING FROM ITS USE.
+
+
+THE SOURCE CODE
+
+Stream To Speaker is open source. The complete source code these
+binaries were built from is available, at no charge, under the Mozilla
+Public License 2.0 at:
+
+    https://github.com/Mihonarium/StreamToSpeaker
+
+Under the MPL you may read, modify, and build the source and distribute
+your own builds. License text: https://mozilla.org/MPL/2.0/
+
+
+THIRD-PARTY CODE
+
+  - The virtual audio driver derives from Microsoft's "sysvad" sample
+    driver, used under the MIT License.
+  - UPnP/SSDP discovery and streaming patterns derive from swyh-rs
+    (https://github.com/dheijl/swyh-rs), used under the MIT License.
+  - The installer bundles devcon.exe, a Windows Driver Kit
+    redistributable, under the MIT License.

--- a/installer/StreamToSpeaker.iss
+++ b/installer/StreamToSpeaker.iss
@@ -59,7 +59,14 @@ VersionInfoVersion={#VersionInfoVersion}
 DefaultDirName={autopf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
-LicenseFile={#SourcePath}\..\LICENSE
+; The wizard's license page shows the terms for what this installer
+; actually delivers: the signed binaries (all rights reserved — see
+; LICENSE-BINARIES.md) plus the MPL-2.0 source-availability notice
+; that MPL §3.2 requires for executable-form distribution. Showing
+; the raw MPL here would misstate the user's rights over the signed
+; binaries; showing the binary terms alone would omit the source
+; notice. LICENSE-INSTALLER.txt covers both, plus third-party credits.
+LicenseFile={#SourcePath}\LICENSE-INSTALLER.txt
 OutputDir={#SourcePath}\out
 OutputBaseFilename={#MyAppShortName}Setup-{#AppVersion}
 Compression=lzma2
@@ -148,8 +155,14 @@ Source: "{#SourcePath}\staging\devcon.exe"; DestDir: "{app}\driver"; Flags: igno
 Source: "{#SourcePath}\staging\StreamToSpeaker.cer"; DestDir: "{app}\driver"; Flags: ignoreversion skipifsourcedoesntexist
 
 ; --- Docs ---
-Source: "{#SourcePath}\..\README.md"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#SourcePath}\..\LICENSE";   DestDir: "{app}"; Flags: ignoreversion
+; LICENSE (MPL-2.0) covers the source; LICENSE-BINARIES.md covers the
+; signed artifacts; LICENSE-INSTALLER.txt is the combined summary the
+; user accepted on the wizard's license page. Install all three so the
+; accepted terms stay on disk.
+Source: "{#SourcePath}\..\README.md";           DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourcePath}\..\LICENSE";             DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourcePath}\..\LICENSE-BINARIES.md"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourcePath}\LICENSE-INSTALLER.txt";  DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}";         Filename: "{app}\{#MyAppExeName}"; Tasks: startmenuicon


### PR DESCRIPTION
## Problem

The installer's license page showed the raw MPL-2.0 text (`LicenseFile={#SourcePath}\..\LICENSE`). An end user running the installer receives **binaries**, so the binary terms in `LICENSE-BINARIES.md` are what actually apply to them — the MPL page overstated their rights (it implies they may redistribute/modify what they just installed). Conversely, showing `LICENSE-BINARIES.md` alone would drop the notice MPL-2.0 §3.2 requires when Covered Software is distributed in executable form: recipients must be informed how to obtain the source under the MPL.

## Change

- **`installer/LICENSE-INSTALLER.txt`** — a short plain-English license page for the wizard:
  - binary terms: install and use freely (any purpose, any number of machines); no redistribution or modification of the signed artifacts; trademark reserved; link to the full `LICENSE-BINARIES.md`;
  - the §3.2 source notice: complete source available at no charge under MPL-2.0 at the repo URL, with the MPL link;
  - third-party credits: Microsoft sysvad sample (MIT), swyh-rs (MIT), bundled devcon.exe (MIT).
- **`installer/StreamToSpeaker.iss`** — `LicenseFile` now points at the new file (with a comment explaining why neither existing license file alone is right); the Docs section additionally installs `LICENSE-BINARIES.md` and `LICENSE-INSTALLER.txt` next to `LICENSE` so the terms the user accepted stay on disk.

## Verified against Inno Setup docs

- `LicenseFile` accepts `.txt` or `.rtf`; Unicode `.txt` must be UTF-8 (BOM optional) or UTF-16LE. The new file is pure ASCII, so encoding is a non-issue on any Inno 6 version, including the choco-installed one CI uses.
- Relative `LicenseFile` paths resolve against the source directory, but this script consistently uses explicit `{#SourcePath}` paths; the new directive matches that convention (the file sits next to the `.iss`, so `{#SourcePath}\LICENSE-INSTALLER.txt`).