### PR TITLE
Privacy policy and Store listing draft

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,64 @@
+# Privacy Policy
+
+**Stream To Speaker collects nothing.** There are no servers, no accounts, no
+analytics, no telemetry, and no crash reporting. Nothing about you or your
+computer is sent to us, because there is nowhere for it to be sent.
+
+Last updated: 7 August 2026.
+
+## What leaves your computer
+
+Only your audio, only to the speaker you pick, and only across your own
+network:
+
+- **Discovery.** The app broadcasts standard discovery messages (SSDP for
+  UPnP/OpenHome speakers, mDNS for AirPlay) on your local network to find
+  speakers, and listens for their replies.
+- **Playback.** Once you select a speaker, the audio Windows is playing is
+  streamed to that speaker's address on your local network, along with the
+  control messages needed to start, stop and set volume.
+
+None of this traffic leaves your network or passes through us.
+
+## What is stored on your computer
+
+- **Settings** — `%APPDATA%\Stream To Speaker\config.json`: your last chosen
+  speaker, latency and reconnect preferences, and, if you use AirPlay
+  speakers that require them, **speaker passwords and pairing keys**. These
+  are stored in plain text in your user profile so the app can reconnect
+  without asking again. Delete the file to clear them.
+- **Log file** — diagnostic output, including speaker names and local IP
+  addresses. It stays on your machine; it is only shared if you choose to
+  attach it to a bug report.
+
+Uninstalling removes the program. Delete the folder above to remove settings
+and logs as well.
+
+## The optional web interface
+
+Stream To Speaker can expose a small web page and HTTP API for controlling it
+from another device. **This is off unless you start the app with `--web`.**
+When enabled it has no authentication and is reachable by anything on your
+network, so enable it only on networks you trust — or bind it to your own
+machine with `--bind 127.0.0.1`.
+
+## Links to other sites
+
+The app has links that open your browser: the project page on GitHub, and a
+donation page on Buy Me a Coffee. Those sites are run by other companies and
+have their own privacy policies. Nothing is sent to them unless you click.
+
+## Children
+
+The app is not directed at children and collects no personal information from
+anyone.
+
+## Changes
+
+Any change to this policy will be committed to this file, so its full history
+is public.
+
+## Contact
+
+Questions: open an issue at
+<https://github.com/Mihonarium/StreamToSpeaker/issues>.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Offline: `--bundle <file>.sigstore.json`, shipped with each release.
 Architecture, building from source, HTTP API: [TECHNICAL.md](TECHNICAL.md).
 Driver signing pipeline: [docs/driver-signing.md](docs/driver-signing.md).
 
+## Privacy
+
+Nothing is collected: no servers, no accounts, no telemetry.
+[PRIVACY.md](PRIVACY.md).
+
 ## License
 
 Source [MPL-2.0](LICENSE). Released binaries: free to install and use,

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,0 +1,92 @@
+# Microsoft Store listing — draft copy
+
+Paste-ready text for Partner Center. Field names match the Store listing form.
+Character limits are Microsoft's.
+
+---
+
+## Product name
+
+Stream To Speaker
+
+## Short description (≤ 200 characters)
+
+Play your PC's sound on the speakers you already own. Stream To Speaker sends
+Windows audio to Sonos, AirPlay and other network speakers around the house.
+
+## Description (≤ 10,000 characters)
+
+Your computer's audio, playing on real speakers anywhere in the house.
+
+Stream To Speaker adds an audio output to Windows. Choose it, pick a speaker,
+and whatever you play — music, a film, a call, anything at all — comes out of
+the speakers in the next room instead of your laptop.
+
+It works with the speakers you already have. Sonos and IKEA SYMFONISK, KEF,
+Denon HEOS, MoOde, Volumio and anything else that speaks UPnP or OpenHome; and
+over AirPlay, HomePod, AirPort Express and shairport-sync. Speakers of both
+kinds show up in the same list.
+
+Nothing routes through the internet. Audio travels directly from your PC to
+your speaker across your own network, and the app has no servers, no accounts
+and no telemetry.
+
+**What it does**
+
+• Sends any Windows audio to a network speaker — not just one app's, and not
+  just music
+• Finds speakers automatically, and remembers the one you use
+• Keeps Windows volume and the speaker's own buttons in step, both ways
+• Lets you trim audio delay while it plays, so sound and picture stay together
+• Routes a single app instead of everything, using the Windows Volume Mixer
+• Sits in the system tray, out of the way
+
+**Good to know**
+
+The audio device it installs is signed by Microsoft, so it works on a normal
+Windows machine with Secure Boot on — no special modes to enable.
+
+Stream To Speaker is open source. The full source code is public, and every
+released build carries proof of which commit it was built from.
+
+## Search terms (≤ 7, ≤ 30 characters each)
+
+sonos, airplay, cast audio, speaker, stream audio, upnp, whole home audio
+
+## Category
+
+Music & Video  →  Music
+
+## Privacy policy URL
+
+https://github.com/Mihonarium/StreamToSpeaker/blob/main/PRIVACY.md
+
+## Support contact
+
+https://github.com/Mihonarium/StreamToSpeaker/issues
+
+## System requirements
+
+Windows 10 version 1809 or later, or Windows 11, 64-bit.
+A speaker on the same network supporting UPnP/OpenHome or AirPlay.
+Not supported on Windows Server.
+
+---
+
+## Screenshots still needed
+
+The Store wants at least one 1366×768 or larger. Worth capturing:
+
+1. Main window with speakers found and one streaming — the whole product in
+   one image.
+2. Windows Sound output picker showing "Stream To Speaker" selected — answers
+   "how does it get my audio?" before it's asked.
+3. The latency controls, since that is the feature competitors lack.
+4. The tray menu.
+
+## Age rating
+
+The questionnaire will ask about user-generated content, data collection and
+purchases. All three are "no": no accounts, no sharing, no in-app purchase.
+The donation link opens an external browser page — declare it if the
+questionnaire asks about external commerce links.


### PR DESCRIPTION
Groundwork for a Microsoft Store submission.

**PRIVACY.md** — written from an audit of the code rather than boilerplate. A sweep of `service/src` found no telemetry, analytics, update checks or crash reporting, and the only outbound URLs are the GitHub and Buy Me a Coffee links the user clicks; the other URLs in source are XML namespace identifiers, never fetched. So the policy can say *nothing is collected* and mean it.

Two disclosures boilerplate would have missed:

- `config.json` stores **AirPlay speaker passwords and pairing keys in plain text** in the user profile. Users deserve to know that, and where to delete it.
- `--web` exposes an **unauthenticated** API to the whole local network. The policy says so and points at `--bind 127.0.0.1`.

**docs/store-listing.md** — paste-ready listing copy, plus a screenshot shot-list and notes on the age-rating questionnaire. It assumes an **unpackaged Win32 listing**: MSIX cannot install kernel-mode drivers, so packaging this app would strip out the audio device it depends on.

README gains a two-line Privacy section pointing at the policy — the Store requires a public URL, and `PRIVACY.md` on main gives a stable, version-controlled one.
