### PR TITLE
Sonos speaker groups: one entry per group, group volume, safe selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,15 @@ User-machine prerequisites that aren't automatable:
 - Windows 10 1809+ (the INF targets `NTamd64.10.0...17763`)
 - Click "Allow" once in Sound Settings for the per-device privacy gate (Windows 11 22H2+ only) — addressed by `PKEY_AudioDevice_EnableEndpointByDefault` in the INF, but pre-existing endpoints created without that property still need the manual click
 
+## Key knowledge — Sonos zone groups (research-verified 2026-08-09 vs SoCo, svrooij/sonos-api-docs, node-sonos-ts)
+
+Implemented in `service/src/sonos.rs` (+ ssdp/upnp/gena/app wiring). Facts below were verified against SoCo's `zonegroupstate.py`/`core.py` and svrooij's service docs — NOT against real grouped hardware yet:
+
+- **Topology**: `GetZoneGroupState` (no args) on `urn:schemas-upnp-org:service:ZoneGroupTopology:1`, control URL `/ZoneGroupTopology/Control`, answered by **any** player. Output `ZoneGroupState` = entity-escaped XML. S2 firmware wraps `<ZoneGroups>` inside `<ZoneGroupState>`; pre-10.1 S1 has `<ZoneGroup>` directly under the root (SoCo's compatibility fallback — we walk descendants so both parse). `ZoneGroup` has `Coordinator` + `ID`; `ZoneGroupMember` has `UUID` (no `uuid:` prefix, unlike UDN), `Location` (that member's device-description URL), `ZoneName`, `Invisible="1"` (stereo-pair slave / Sub), `IsZoneBridge="1"` (BRIDGE/BOOST — filter these too, SoCo does), and `Satellite` child elements (surrounds) which we fold in as invisible members. The service also EVENTS ZoneGroupState via GENA — unused today; would give live group-change updates instead of per-scan.
+- **Group membership mechanism**: `SetAVTransportURI` with `x-rincon:<coordinator-UUID>` = join a group; `BecomeCoordinatorOfStandaloneGroup` = leave. A normal stream URI to a grouped member changes its membership (this is why we hide members; SoCo raises client-side on ANY transport call to a non-coordinator).
+- **Group volume**: `urn:schemas-upnp-org:service:GroupRenderingControl:1` at `/MediaRenderer/GroupRenderingControl/Control|Event` — `SetGroupVolume(InstanceID=0, DesiredVolume)` / `GetGroupVolume` / `SetGroupMute(DesiredMute)` / `SetRelativeGroupVolume(Adjustment) → NewVolume` / `SnapshotGroupVolume`. Coordinator-only: **error 701 "Player isn't the coordinator"** elsewhere. Scales members proportionally (the Sonos-app group slider). GENA events are **flat** properties (`<GroupVolume>`, `<GroupMute>`, `<GroupVolumeChangeable>` — booleans as 1/0), NOT LastChange-wrapped like RenderingControl; `parse_rendering_notify` handles both shapes.
+- **Transport gotcha**: Sonos chunks HTTP/1.1 responses. `ssdp.rs http_get` dodges via HTTP/1.0; `upnp.rs soap_post` speaks 1.1 and now de-chunks the body (`decode_maybe_chunked`) — small SOAP replies fit one chunk and parsed "fine" by accident for years, a multi-KB `GetZoneGroupState` would have had interior chunk-size lines corrupting the escaped XML.
+
 ## Key knowledge — Windows-audio specifics learned the hard way
 
 | Symptom | Real cause | Fix |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ and run it. Needs Windows 10 1809+ / Windows 11, 64-bit (not Windows Server).
    app to it in the Volume Mixer.
 2. Pick a speaker in the app.
 
+Sonos speakers grouped in the Sonos app show up as one entry ("Living Room +
+Kitchen"); audio plays on the whole group and the volume slider moves the
+group volume. To stream to a single speaker, ungroup it in the Sonos app.
+
 Sound lagging behind video → **−25 / −100 ms**. No sound → **Resync**
 (`Ctrl+Shift+R`). Speaker missing → **↻ Rescan**; check it's on the same
 network as the PC.

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -115,19 +115,29 @@ substring or an IPv4 literal; `--list-speakers` prints and exits. Without
 
 ### Sonos groups
 
-Discovery queries the Sonos `ZoneGroupTopology` service (`GetZoneGroupState`)
-and folds the zone-group state into the list (`sonos.rs`): bonded invisible
-units (stereo-pair slaves, Subs, surrounds) and grouped non-coordinator
-members are hidden — sending `SetAVTransportURI` to a member would silently
-rip it out of its group — and each group appears as its coordinator, named
-"Living Room + Kitchen" (or "+ N" beyond two). `--player` also matches group
-member names. Selecting a speaker re-checks topology from the device itself
-and redirects to its current coordinator, so a list stale by up to one
-discovery interval can't break a group. Group sessions route volume through
-`GroupRenderingControl` on the coordinator (`SetGroupVolume` scales every
-member, like the Sonos app's group slider) and subscribe GENA to its flat
-`GroupVolume`/`GroupMute` events instead of `RenderingControl`'s
-`LastChange`.
+Discovery queries the Sonos `ZoneGroupTopology` service (`GetZoneGroupState`,
+answered by any player) and folds the zone-group state into the list
+(`sonos.rs`): bonded invisible units (stereo-pair slaves, Subs, surrounds —
+`Invisible="1"` members and `Satellite` children), BRIDGE/BOOST units
+(`IsZoneBridge="1"`), and grouped non-coordinator members are hidden, and
+each group appears as its coordinator, named "Living Room + Kitchen" (or
+"+ N" beyond two). Members are hidden because `SetAVTransportURI` *is*
+Sonos's group-membership mechanism — `x-rincon:<coordinator-UUID>` joins a
+zone to a group, so pointing a member at a normal stream URI changes its
+membership instead of coexisting with it (SoCo hard-errors client-side on
+any transport call to a non-coordinator for the same reason). `--player`
+also matches group member names. Selecting a speaker re-checks topology from
+the device itself and redirects to its current coordinator, so a list stale
+by up to one discovery interval can't break a group. Group sessions route
+volume through `GroupRenderingControl` on the coordinator —
+`SetGroupVolume`/`SetGroupMute` scale every member proportionally like the
+Sonos app's group slider, and error 701 anywhere else — and subscribe GENA
+to its flat `GroupVolume`/`GroupMute` events instead of `RenderingControl`'s
+`LastChange`. Both ZoneGroupState shapes are handled (S2 wraps
+`<ZoneGroups>` in `<ZoneGroupState>`; pre-10.1 S1 doesn't), and the SOAP
+client de-chunks response bodies — Sonos chunks HTTP/1.1 responses, which
+small replies survive by accident but a multi-KB `GetZoneGroupState` does
+not.
 
 ## Latency control
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -113,6 +113,22 @@ substring or an IPv4 literal; `--list-speakers` prints and exits. Without
 `POST /api/select` with `{"id": "<udn-or-ip>"}`. Discovery re-runs every
 `--ssdp-interval` minutes.
 
+### Sonos groups
+
+Discovery queries the Sonos `ZoneGroupTopology` service (`GetZoneGroupState`)
+and folds the zone-group state into the list (`sonos.rs`): bonded invisible
+units (stereo-pair slaves, Subs, surrounds) and grouped non-coordinator
+members are hidden — sending `SetAVTransportURI` to a member would silently
+rip it out of its group — and each group appears as its coordinator, named
+"Living Room + Kitchen" (or "+ N" beyond two). `--player` also matches group
+member names. Selecting a speaker re-checks topology from the device itself
+and redirects to its current coordinator, so a list stale by up to one
+discovery interval can't break a group. Group sessions route volume through
+`GroupRenderingControl` on the coordinator (`SetGroupVolume` scales every
+member, like the Sonos app's group slider) and subscribe GENA to its flat
+`GroupVolume`/`GroupMute` events instead of `RenderingControl`'s
+`LastChange`.
+
 ## Latency control
 
 End-to-end latency is `Windows engine + driver buffer + network + speaker

--- a/service/Cargo.lock
+++ b/service/Cargo.lock
@@ -3620,7 +3620,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stream-to-speaker"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "alac",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-to-speaker"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.74"
 description = "Stream To Speaker — user-mode bridge between a Windows virtual audio driver (or WASAPI loopback) and any UPnP/OpenHome network speaker (Sonos, IKEA StreamToSpeaker, etc)."

--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -59,7 +59,9 @@ impl ActiveSession {
 
     pub fn friendly_name(&self) -> String {
         match self {
-            ActiveSession::Upnp(s) => s.renderer.friendly_name.clone(),
+            // display_name shows "Living Room + Kitchen" when streaming
+            // to a Sonos group (identical to friendly_name otherwise).
+            ActiveSession::Upnp(s) => s.renderer.display_name(),
             ActiveSession::AirPlay(s) => s.renderer.friendly_name.clone(),
             ActiveSession::AirPlay2(s) => s.renderer.friendly_name.clone(),
         }
@@ -85,13 +87,15 @@ impl ActiveSession {
     }
 
     /// Push a volume change to the speaker. UPnP path goes via
-    /// SetVolume SOAP; AirPlay path goes via SET_PARAMETER over the
-    /// existing RTSP socket.
+    /// SetVolume SOAP (SetGroupVolume when streaming to a Sonos group,
+    /// so the whole group scales like its Sonos-app slider); AirPlay
+    /// path goes via SET_PARAMETER over the existing RTSP socket.
     pub fn set_volume_pct(&self, pct: u32) -> Result<()> {
         match self {
-            ActiveSession::Upnp(s) => {
-                upnp::set_volume(&s.renderer.rendering_control_control_url, pct)
-            }
+            ActiveSession::Upnp(s) => match s.renderer.group_volume_control_url() {
+                Some(url) => upnp::set_group_volume(url, pct),
+                None => upnp::set_volume(&s.renderer.rendering_control_control_url, pct),
+            },
             ActiveSession::AirPlay(s) => s.set_volume_pct(pct),
             ActiveSession::AirPlay2(s) => s.set_volume_pct(pct),
         }
@@ -121,9 +125,10 @@ impl ActiveSession {
     /// Push a mute state to the speaker.
     pub fn set_mute(&self, muted: bool) -> Result<()> {
         match self {
-            ActiveSession::Upnp(s) => {
-                upnp::set_mute(&s.renderer.rendering_control_control_url, muted)
-            }
+            ActiveSession::Upnp(s) => match s.renderer.group_volume_control_url() {
+                Some(url) => upnp::set_group_mute(url, muted),
+                None => upnp::set_mute(&s.renderer.rendering_control_control_url, muted),
+            },
             ActiveSession::AirPlay(s) => s.set_mute(muted),
             ActiveSession::AirPlay2(s) => s.set_mute(muted),
         }
@@ -534,12 +539,29 @@ impl App {
                 let id = r.stable_id();
                 let active = active_id.as_deref() == Some(id.as_str());
                 upnp_ips.insert(r.ip.to_string());
+                // Sonos group coordinators present as one row for the
+                // whole group ("Living Room + Kitchen"); the grouped
+                // members themselves are filtered out at discovery time
+                // because streaming to one would silently ungroup it.
+                let note = r.is_group().then(|| {
+                    let mut all = vec![r
+                        .zone_name
+                        .clone()
+                        .unwrap_or_else(|| r.friendly_name.clone())];
+                    all.extend(r.group_members.iter().cloned());
+                    format!(
+                        "Sonos group: {}. Audio plays on every speaker in the group and the \
+                         volume slider moves the whole group. To stream to a single speaker, \
+                         ungroup it in the Sonos app first.",
+                        all.join(" + ")
+                    )
+                });
                 speakers.push(SpeakerInfo {
                     id,
-                    friendly_name: r.friendly_name,
+                    friendly_name: r.display_name(),
                     ip: r.ip.to_string(),
                     active,
-                    note: None,
+                    note,
                 });
             }
         }
@@ -669,7 +691,7 @@ impl App {
                 .discovery
                 .as_ref()
                 .and_then(|d| d.find_by_id(id))
-                .map(|r| r.friendly_name)
+                .map(|r| r.display_name())
                 .or_else(|| {
                     self.airplay_discovery
                         .as_ref()
@@ -917,6 +939,11 @@ impl App {
             }
         }
 
+        // The session's stable id can legitimately differ from the
+        // requested one: selecting a Sonos that joined a group since the
+        // last scan streams to its group coordinator instead (see
+        // start_upnp). Remember the id we actually bound so reconnect /
+        // active-row highlighting track reality.
         let new_session = if id.starts_with("airplay:") {
             match self.start_airplay(id) {
                 Ok(s) => s,
@@ -953,6 +980,7 @@ impl App {
         } else {
             self.start_upnp(id)?
         };
+        let actual_id = new_session.stable_id();
 
         let mut guard = self.session.lock().unwrap();
         if let Some(old) = guard.take() {
@@ -979,7 +1007,7 @@ impl App {
         let new_friendly_name = guard.as_ref().map(|s| s.friendly_name());
         drop(guard);
 
-        *self.last_speaker_id.lock().unwrap() = Some(id.to_string());
+        *self.last_speaker_id.lock().unwrap() = Some(actual_id.clone());
         self.streaming_enabled.store(true, Ordering::Release);
         // Persist so the next launch can auto-reconnect. We do NOT
         // auto-dismiss the onboarding here — picking a speaker only
@@ -990,8 +1018,8 @@ impl App {
         // click "Hide this guide" themselves.
         {
             let mut uc = self.user_config.lock().unwrap();
-            if uc.last_speaker_id.as_deref() != Some(id) {
-                uc.last_speaker_id = Some(id.to_string());
+            if uc.last_speaker_id.as_deref() != Some(actual_id.as_str()) {
+                uc.last_speaker_id = Some(actual_id.clone());
                 uc.save();
             }
         }
@@ -1011,9 +1039,14 @@ impl App {
         // can block ~100 ms.
         if let Some(r) = new_upnp_renderer {
             let vsync = self.vsync.clone();
-            let url = r.rendering_control_control_url.clone();
             std::thread::spawn(move || {
-                if let Ok(level) = upnp::get_volume(&url) {
+                // Group sessions prime from the group volume — that's
+                // what the slider will be driving.
+                let level = match r.group_volume_control_url() {
+                    Some(url) => upnp::get_group_volume(url),
+                    None => upnp::get_volume(&r.rendering_control_control_url),
+                };
+                if let Ok(level) = level {
                     vsync.prime_initial_volume(level);
                 }
             });
@@ -1028,6 +1061,15 @@ impl App {
             .ok_or_else(|| "UPnP discovery disabled".to_string())?;
         let Some(new_r) = discovery.find_by_id(id) else {
             return Err(format!("no UPnP speaker with id {:?}", id));
+        };
+        // Sonos: the discovery list can be minutes stale, and streaming
+        // to a zone that has since been grouped would silently rip it
+        // out of its group. Re-check topology from the device itself and
+        // stream to the group coordinator (= the whole group) instead.
+        // No-op for non-Sonos renderers; fails open on network errors.
+        let new_r = {
+            let d = discovery.clone();
+            crate::sonos::resolve_group_coordinator(new_r, &move |cid| d.find_by_id(cid))
         };
         let didl = upnp::didl_lite_metadata(
             &self.config.stream_uri,
@@ -1787,7 +1829,7 @@ pub fn start_session(
     didl: &str,
     callback_url: &str,
 ) -> Result<RendererSession> {
-    info!("targeting speaker: {} ({})", renderer.friendly_name, renderer.ip);
+    info!("targeting speaker: {} ({})", renderer.display_name(), renderer.ip);
     // Stop first to clear any "Transport Locked" (Sonos 705) carry-over.
     let _ = upnp::stop(&renderer.av_transport_control_url);
     std::thread::sleep(Duration::from_millis(100));
@@ -1797,7 +1839,9 @@ pub fn start_session(
     upnp::play(&renderer.av_transport_control_url).context("Play")?;
 
     let gena = GenaManager::new(callback_url.to_string());
-    match gena.subscribe(&renderer.rendering_control_event_url) {
+    // Groups subscribe to GroupRenderingControl (GroupVolume events —
+    // the group slider), standalone speakers to RenderingControl.
+    match gena.subscribe(renderer.volume_event_url()) {
         Ok(_) => {
             gena.clone().spawn_renewer();
         }

--- a/service/src/gena.rs
+++ b/service/src/gena.rs
@@ -119,13 +119,27 @@ impl GenaManager {
     }
 }
 
-/// Parse a NOTIFY body for RenderingControl LastChange events. Returns
-/// None if we can't extract anything useful (which is fine — we'll just
-/// ignore the notify).
+/// Parse a NOTIFY body for volume/mute changes. Handles both shapes we
+/// subscribe to:
+///
+///  * RenderingControl — a `LastChange` property whose text is an
+///    entity-encoded XML document with `<Volume>` / `<Mute>` elements;
+///  * GroupRenderingControl (Sonos group volume) — flat `<GroupVolume>`
+///    / `<GroupMute>` properties, no LastChange wrapper.
+///
+/// Returns None if we can't extract anything useful (which is fine —
+/// we'll just ignore the notify).
 pub fn parse_rendering_notify(body: &str) -> Option<RenderingChange> {
-    // The body is propertyset -> property -> LastChange (text node,
-    // entity-encoded).  Extract LastChange.
-    let lc = find_tag_text(body, "LastChange")?;
+    let Some(lc) = find_tag_text(body, "LastChange") else {
+        // GroupRenderingControl notifies carry flat properties.
+        let volume = find_tag_text(body, "GroupVolume").and_then(|v| v.trim().parse::<u32>().ok());
+        let mute = find_tag_text(body, "GroupMute")
+            .map(|v| v.trim() == "1" || v.trim().eq_ignore_ascii_case("true"));
+        if volume.is_none() && mute.is_none() {
+            return None;
+        }
+        return Some(RenderingChange { volume, mute });
+    };
     // LastChange is XML-encoded inside the text node.
     let decoded = xml_unescape(&lc);
 
@@ -280,8 +294,9 @@ fn extract_header(response: &str, header: &str) -> Option<String> {
     None
 }
 
-/// Pull the text between the first `<tag>...</tag>` pair.
-fn find_tag_text(xml: &str, tag: &str) -> Option<String> {
+/// Pull the text between the first `<tag>...</tag>` pair. Also used by
+/// upnp.rs / sonos.rs for the ZoneGroupState payload.
+pub(crate) fn find_tag_text(xml: &str, tag: &str) -> Option<String> {
     let open = format!("<{}>", tag);
     let close = format!("</{}>", tag);
     let i = xml.find(&open)?;
@@ -290,7 +305,7 @@ fn find_tag_text(xml: &str, tag: &str) -> Option<String> {
     Some(after[..j].to_string())
 }
 
-fn xml_unescape(s: &str) -> String {
+pub(crate) fn xml_unescape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut i = 0;
     let bytes = s.as_bytes();
@@ -344,5 +359,27 @@ mod tests {
     #[test]
     fn xml_unescape_basic() {
         assert_eq!(xml_unescape("a &amp; b &lt;c&gt; &quot;d&quot;"), "a & b <c> \"d\"");
+    }
+
+    #[test]
+    fn parses_group_volume_change() {
+        // GroupRenderingControl NOTIFY — flat properties, no LastChange.
+        let body = r#"<?xml version="1.0"?>
+<e:propertyset xmlns:e="urn:schemas-upnp-org:event-1-0">
+<e:property><GroupVolume>32</GroupVolume></e:property>
+<e:property><GroupMute>1</GroupMute></e:property>
+<e:property><GroupVolumeChangeable>1</GroupVolumeChangeable></e:property>
+</e:propertyset>"#;
+        let rc = parse_rendering_notify(body).expect("decode");
+        assert_eq!(rc.volume, Some(32));
+        assert_eq!(rc.mute, Some(true));
+    }
+
+    #[test]
+    fn ignores_empty_group_notify() {
+        let body = r#"<e:propertyset xmlns:e="urn:schemas-upnp-org:event-1-0">
+<e:property><GroupVolumeChangeable>1</GroupVolumeChangeable></e:property>
+</e:propertyset>"#;
+        assert!(parse_rendering_notify(body).is_none());
     }
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -10,6 +10,7 @@ pub mod audio_loop;
 pub mod audio_source;
 pub mod silence;
 pub mod http_server;
+pub mod sonos;
 pub mod ssdp;
 pub mod upnp;
 pub mod gena;

--- a/service/src/picker.rs
+++ b/service/src/picker.rs
@@ -32,7 +32,8 @@ pub fn print_speaker_list(renderers: &[Renderer]) -> usize {
     println!();
     println!("Discovered speakers:");
     for (i, r) in renderers.iter().enumerate() {
-        println!("  [{}]  {}  ({})", i + 1, r.friendly_name, r.ip);
+        // display_name shows Sonos groups as "Living Room + Kitchen".
+        println!("  [{}]  {}  ({})", i + 1, r.display_name(), r.ip);
     }
     println!();
     renderers.len()
@@ -134,7 +135,7 @@ pub fn resolve(
                     q,
                     renderers
                         .iter()
-                        .map(|r| r.friendly_name.clone())
+                        .map(|r| r.display_name())
                         .collect::<Vec<_>>()
                 ));
             }
@@ -148,7 +149,7 @@ pub fn resolve(
     if renderers.len() > 1 {
         log::warn!(
             "multiple speakers discovered; defaulting to first ({}). Use --player <name> to pick.",
-            renderers[0].friendly_name
+            renderers[0].display_name()
         );
     }
     Ok(renderers.into_iter().next())

--- a/service/src/sonos.rs
+++ b/service/src/sonos.rs
@@ -1,0 +1,457 @@
+//! Sonos zone-group topology.
+//!
+//! Sonos speakers can be grouped in the Sonos app; a group has exactly one
+//! *coordinator* and the rest are members that mirror its audio. Two facts
+//! drive everything here:
+//!
+//!  * AVTransport commands only make sense on the coordinator. Sending
+//!    `SetAVTransportURI` to a non-coordinator member silently rips it out
+//!    of its group (that is how Sonos "moves" a zone between groups).
+//!  * Volume for the whole group lives on the coordinator's
+//!    `GroupRenderingControl` service (`SetGroupVolume` scales every
+//!    member proportionally, exactly like the group slider in the Sonos
+//!    app); the plain `RenderingControl` volume only moves the
+//!    coordinator's own speaker.
+//!
+//! Topology comes from the `ZoneGroupTopology` service every Sonos device
+//! exposes on its root device: `GetZoneGroupState` returns an
+//! entity-encoded XML document listing groups, coordinators, members and
+//! their visibility. Bonded satellites (the right speaker of a stereo
+//! pair, a Sub, surrounds) are marked `Invisible="1"` — they answer SSDP
+//! but must never be offered as targets.
+//!
+//! Non-Sonos renderers (no ZoneGroupTopology service) pass through
+//! untouched, and every network failure here fails open: worst case the
+//! list looks like it did before this module existed.
+
+use crate::ssdp::Renderer;
+use crate::upnp;
+use log::{debug, info};
+
+/// One zone group as reported by ZoneGroupTopology.
+#[derive(Debug, Clone)]
+pub struct ZoneGroup {
+    /// UUID (RINCON_...) of the coordinator zone.
+    pub coordinator_uuid: String,
+    pub members: Vec<ZoneMember>,
+}
+
+/// One member zone (or bonded satellite) of a group.
+#[derive(Debug, Clone)]
+pub struct ZoneMember {
+    /// UUID without the `uuid:` prefix, e.g. `RINCON_949F3EC2E15801400`.
+    pub uuid: String,
+    /// Room name ("Living Room").
+    pub zone_name: String,
+    /// URL of this member's own device description.
+    pub location: String,
+    /// True for bonded units that must not be shown (stereo-pair slave,
+    /// Sub, surrounds) — they can't be targeted independently.
+    pub invisible: bool,
+}
+
+impl ZoneGroup {
+    /// Zone names of the visible members, coordinator first.
+    pub fn visible_member_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = Vec::new();
+        if let Some(c) = self.members.iter().find(|m| m.uuid == self.coordinator_uuid) {
+            names.push(c.zone_name.clone());
+        }
+        for m in &self.members {
+            if m.uuid != self.coordinator_uuid && !m.invisible {
+                names.push(m.zone_name.clone());
+            }
+        }
+        names
+    }
+}
+
+/// Fetch and parse the zone-group state from a device's ZoneGroupTopology
+/// control URL.
+pub fn fetch_zone_groups(control_url: &str) -> anyhow::Result<Vec<ZoneGroup>> {
+    let body = upnp::get_zone_group_state(control_url)?;
+    Ok(parse_zone_group_state(&body))
+}
+
+/// Parse the (already entity-decoded) ZoneGroupState XML document.
+///
+/// Shape (current firmware wraps it in `<ZoneGroupState><ZoneGroups>`,
+/// older firmware returned `<ZoneGroups>` directly — we just walk to the
+/// `ZoneGroup` elements wherever they are):
+///
+/// ```xml
+/// <ZoneGroups>
+///   <ZoneGroup Coordinator="RINCON_A" ID="RINCON_A:42">
+///     <ZoneGroupMember UUID="RINCON_A" Location="http://..." ZoneName="Living Room">
+///       <Satellite UUID="RINCON_S" Location="http://..." ZoneName="Living Room" Invisible="1"/>
+///     </ZoneGroupMember>
+///     <ZoneGroupMember UUID="RINCON_B" Location="http://..." ZoneName="Kitchen"/>
+///   </ZoneGroup>
+/// </ZoneGroups>
+/// ```
+pub fn parse_zone_group_state(xml: &str) -> Vec<ZoneGroup> {
+    let doc = match roxmltree::Document::parse(xml.trim_start()) {
+        Ok(d) => d,
+        Err(e) => {
+            debug!("ZoneGroupState parse failed: {}", e);
+            return Vec::new();
+        }
+    };
+
+    let mut groups = Vec::new();
+    for g in doc
+        .descendants()
+        .filter(|n| n.tag_name().name() == "ZoneGroup")
+    {
+        let Some(coordinator) = g.attribute("Coordinator") else {
+            continue;
+        };
+        let mut members = Vec::new();
+        for m in g.descendants().filter(|n| {
+            let name = n.tag_name().name();
+            // Satellites are bonded sub-units nested inside a member;
+            // fold them in as invisible members so their SSDP entries
+            // get filtered like any other invisible zone.
+            name == "ZoneGroupMember" || name == "Satellite"
+        }) {
+            let Some(uuid) = m.attribute("UUID") else {
+                continue;
+            };
+            let invisible = m.tag_name().name() == "Satellite"
+                || m.attribute("Invisible").map(|v| v == "1").unwrap_or(false);
+            members.push(ZoneMember {
+                uuid: uuid.to_string(),
+                zone_name: m.attribute("ZoneName").unwrap_or("").to_string(),
+                location: m.attribute("Location").unwrap_or("").to_string(),
+                invisible,
+            });
+        }
+        groups.push(ZoneGroup {
+            coordinator_uuid: coordinator.to_string(),
+            members,
+        });
+    }
+    groups
+}
+
+/// Strip the `uuid:` prefix a UPnP UDN carries; topology UUIDs don't
+/// have it.
+fn bare_uuid(udn: &str) -> &str {
+    udn.strip_prefix("uuid:").unwrap_or(udn)
+}
+
+/// Fold zone-group topology into a freshly-discovered renderer list:
+///
+///  * invisible zones (stereo-pair slaves, Subs, surrounds) are removed;
+///  * non-coordinator members of a group are removed — selecting one
+///    would ungroup it, and the group is reachable via its coordinator;
+///  * coordinators of multi-member groups get `zone_name` +
+///    `group_members` filled in so the UI can present the group;
+///  * a group whose coordinator's SSDP response got lost gets the
+///    coordinator synthesized from the topology's Location URL (SSDP is
+///    lossy; the members would otherwise all vanish from the list).
+///
+/// `fetch` resolves a device-description URL to a Renderer (injected so
+/// tests can run without a network).
+pub fn apply_topology(
+    renderers: &mut Vec<Renderer>,
+    groups: &[ZoneGroup],
+    fetch: &dyn Fn(&str) -> Option<Renderer>,
+) {
+    // Synthesize coordinators whose SSDP response we missed but whose
+    // group has at least one discovered member.
+    for g in groups {
+        let coordinator_known = renderers
+            .iter()
+            .any(|r| r.udn.as_deref().map(bare_uuid) == Some(g.coordinator_uuid.as_str()));
+        if coordinator_known {
+            continue;
+        }
+        let any_member_discovered = renderers.iter().any(|r| {
+            r.udn
+                .as_deref()
+                .map(|u| g.members.iter().any(|m| m.uuid == bare_uuid(u)))
+                .unwrap_or(false)
+        });
+        let coord_member = g.members.iter().find(|m| m.uuid == g.coordinator_uuid);
+        if let (true, Some(cm)) = (any_member_discovered, coord_member) {
+            if let Some(r) = fetch(&cm.location) {
+                info!(
+                    "Sonos topology: coordinator {} missed SSDP; recovered from topology",
+                    cm.zone_name
+                );
+                renderers.push(r);
+            }
+        }
+    }
+
+    renderers.retain(|r| {
+        let Some(udn) = r.udn.as_deref() else {
+            return true; // non-Sonos / no UDN — leave it alone
+        };
+        let uuid = bare_uuid(udn);
+        for g in groups {
+            if let Some(m) = g.members.iter().find(|m| m.uuid == uuid) {
+                if m.invisible {
+                    return false;
+                }
+                // Grouped under a different coordinator → hidden; the
+                // group entry (the coordinator) is the way to reach it.
+                return g.coordinator_uuid == uuid;
+            }
+        }
+        true // not in the topology at all (non-Sonos renderer)
+    });
+
+    for r in renderers.iter_mut() {
+        let Some(udn) = r.udn.as_deref() else { continue };
+        let uuid = bare_uuid(udn).to_string();
+        for g in groups {
+            if g.coordinator_uuid != uuid {
+                continue;
+            }
+            if let Some(m) = g.members.iter().find(|m| m.uuid == uuid) {
+                r.zone_name = Some(m.zone_name.clone());
+            }
+            r.group_members = g
+                .members
+                .iter()
+                .filter(|m| m.uuid != uuid && !m.invisible)
+                .map(|m| m.zone_name.clone())
+                .collect();
+        }
+    }
+}
+
+/// Discovery-time entry point: query topology from the first Sonos in the
+/// list and fold it in. No-op for Sonos-free networks; fails open on any
+/// error.
+pub fn annotate_with_topology(renderers: &mut Vec<Renderer>) {
+    let Some(zgt_url) = renderers
+        .iter()
+        .find_map(|r| r.zone_group_topology_control_url.clone())
+    else {
+        return;
+    };
+    match fetch_zone_groups(&zgt_url) {
+        Ok(groups) => {
+            apply_topology(renderers, &groups, &|location| {
+                crate::ssdp::fetch_and_parse_device(location, std::time::Duration::from_secs(3))
+                    .ok()
+            });
+        }
+        Err(e) => debug!("Sonos topology query failed (list left as-is): {:#}", e),
+    }
+}
+
+/// Select-time safety net: the discovery list can be minutes stale, so
+/// re-check the target's group membership right before streaming. If it
+/// is now a non-coordinator member, redirect to the coordinator —
+/// streaming to the member would silently ungroup it, and the coordinator
+/// plays on the whole group (which is what a fresh list would have
+/// offered). Also refreshes `group_members` on the (possibly unchanged)
+/// coordinator so volume routing and the status banner are current.
+///
+/// `lookup` resolves a stable id (`uuid:RINCON_...`) against the current
+/// discovery list; the coordinator falls back to a device-description
+/// fetch via the topology's Location when it isn't in the list.
+pub fn resolve_group_coordinator(
+    renderer: Renderer,
+    lookup: &dyn Fn(&str) -> Option<Renderer>,
+) -> Renderer {
+    let Some(zgt_url) = renderer.zone_group_topology_control_url.clone() else {
+        return renderer; // not a Sonos
+    };
+    let Some(udn) = renderer.udn.clone() else {
+        return renderer;
+    };
+    let uuid = bare_uuid(&udn).to_string();
+
+    let groups = match fetch_zone_groups(&zgt_url) {
+        Ok(g) => g,
+        Err(e) => {
+            debug!("pre-stream topology check failed (using speaker as-is): {:#}", e);
+            return renderer;
+        }
+    };
+    let Some(group) = groups.iter().find(|g| g.members.iter().any(|m| m.uuid == uuid)) else {
+        return renderer;
+    };
+
+    let mut target = if group.coordinator_uuid == uuid {
+        renderer
+    } else {
+        let coord_id = format!("uuid:{}", group.coordinator_uuid);
+        let coord_member = group.members.iter().find(|m| m.uuid == group.coordinator_uuid);
+        let coord = lookup(&coord_id).or_else(|| {
+            coord_member.and_then(|m| {
+                crate::ssdp::fetch_and_parse_device(&m.location, std::time::Duration::from_secs(3))
+                    .ok()
+            })
+        });
+        match coord {
+            Some(c) => {
+                info!(
+                    "Sonos: {} is grouped under {}; streaming to the group coordinator",
+                    renderer.friendly_name,
+                    coord_member.map(|m| m.zone_name.as_str()).unwrap_or("its coordinator"),
+                );
+                c
+            }
+            None => {
+                debug!(
+                    "Sonos: couldn't resolve coordinator {} — using {} directly",
+                    group.coordinator_uuid, renderer.friendly_name
+                );
+                return renderer;
+            }
+        }
+    };
+
+    // Refresh group annotations from the just-fetched topology.
+    if let Some(m) = group.members.iter().find(|m| m.uuid == group.coordinator_uuid) {
+        target.zone_name = Some(m.zone_name.clone());
+    }
+    target.group_members = group
+        .members
+        .iter()
+        .filter(|m| m.uuid != group.coordinator_uuid && !m.invisible)
+        .map(|m| m.zone_name.clone())
+        .collect();
+    target
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn renderer(udn: &str, name: &str) -> Renderer {
+        Renderer {
+            friendly_name: name.to_string(),
+            ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)),
+            base_url: "http://192.168.1.10:1400".into(),
+            av_transport_control_url: "http://192.168.1.10:1400/MediaRenderer/AVTransport/Control"
+                .into(),
+            rendering_control_control_url:
+                "http://192.168.1.10:1400/MediaRenderer/RenderingControl/Control".into(),
+            rendering_control_event_url:
+                "http://192.168.1.10:1400/MediaRenderer/RenderingControl/Event".into(),
+            av_transport_event_url: None,
+            udn: Some(udn.to_string()),
+            zone_group_topology_control_url: Some(
+                "http://192.168.1.10:1400/ZoneGroupTopology/Control".into(),
+            ),
+            group_rendering_control_control_url: Some(
+                "http://192.168.1.10:1400/MediaRenderer/GroupRenderingControl/Control".into(),
+            ),
+            group_rendering_control_event_url: Some(
+                "http://192.168.1.10:1400/MediaRenderer/GroupRenderingControl/Event".into(),
+            ),
+            zone_name: None,
+            group_members: Vec::new(),
+        }
+    }
+
+    const SAMPLE: &str = r#"<ZoneGroupState><ZoneGroups>
+<ZoneGroup Coordinator="RINCON_AAA" ID="RINCON_AAA:42">
+  <ZoneGroupMember UUID="RINCON_AAA" Location="http://192.168.1.10:1400/xml/device_description.xml" ZoneName="Living Room">
+    <Satellite UUID="RINCON_SAT" Location="http://192.168.1.13:1400/xml/device_description.xml" ZoneName="Living Room" Invisible="1"/>
+  </ZoneGroupMember>
+  <ZoneGroupMember UUID="RINCON_BBB" Location="http://192.168.1.11:1400/xml/device_description.xml" ZoneName="Kitchen"/>
+</ZoneGroup>
+<ZoneGroup Coordinator="RINCON_CCC" ID="RINCON_CCC:7">
+  <ZoneGroupMember UUID="RINCON_CCC" Location="http://192.168.1.12:1400/xml/device_description.xml" ZoneName="Bedroom"/>
+</ZoneGroup>
+</ZoneGroups></ZoneGroupState>"#;
+
+    #[test]
+    fn parses_groups_members_satellites() {
+        let groups = parse_zone_group_state(SAMPLE);
+        assert_eq!(groups.len(), 2);
+        let g = &groups[0];
+        assert_eq!(g.coordinator_uuid, "RINCON_AAA");
+        assert_eq!(g.members.len(), 3); // coordinator + satellite + kitchen
+        assert!(g.members.iter().any(|m| m.uuid == "RINCON_SAT" && m.invisible));
+        assert_eq!(g.visible_member_names(), vec!["Living Room", "Kitchen"]);
+        assert_eq!(groups[1].members.len(), 1);
+    }
+
+    #[test]
+    fn hides_members_and_satellites_annotates_coordinator() {
+        let groups = parse_zone_group_state(SAMPLE);
+        let mut renderers = vec![
+            renderer("uuid:RINCON_AAA", "Living Room - Sonos One"),
+            renderer("uuid:RINCON_BBB", "Kitchen - Sonos One"),
+            renderer("uuid:RINCON_SAT", "Living Room - Sonos One (R)"),
+            renderer("uuid:RINCON_CCC", "Bedroom - Sonos One"),
+        ];
+        apply_topology(&mut renderers, &groups, &|_| None);
+        let names: Vec<&str> = renderers.iter().map(|r| r.friendly_name.as_str()).collect();
+        assert_eq!(names, vec!["Living Room - Sonos One", "Bedroom - Sonos One"]);
+        let coord = &renderers[0];
+        assert_eq!(coord.zone_name.as_deref(), Some("Living Room"));
+        assert_eq!(coord.group_members, vec!["Kitchen"]);
+        assert!(coord.is_group());
+        // Standalone zone: no group annotations.
+        let solo = &renderers[1];
+        assert!(solo.group_members.is_empty());
+        assert!(!solo.is_group());
+    }
+
+    #[test]
+    fn non_sonos_renderers_pass_through() {
+        let groups = parse_zone_group_state(SAMPLE);
+        let mut plain = renderer("uuid:other-device", "AVR");
+        plain.zone_group_topology_control_url = None;
+        let mut renderers = vec![plain];
+        apply_topology(&mut renderers, &groups, &|_| None);
+        assert_eq!(renderers.len(), 1);
+    }
+
+    #[test]
+    fn synthesizes_missing_coordinator() {
+        let groups = parse_zone_group_state(SAMPLE);
+        // Only the Kitchen member answered SSDP; the coordinator's
+        // response got lost.
+        let mut renderers = vec![renderer("uuid:RINCON_BBB", "Kitchen - Sonos One")];
+        let fetched = std::cell::RefCell::new(Vec::<String>::new());
+        apply_topology(&mut renderers, &groups, &|loc| {
+            fetched.borrow_mut().push(loc.to_string());
+            Some(renderer("uuid:RINCON_AAA", "Living Room - Sonos One"))
+        });
+        assert_eq!(
+            fetched.borrow().as_slice(),
+            &["http://192.168.1.10:1400/xml/device_description.xml"]
+        );
+        assert_eq!(renderers.len(), 1);
+        assert_eq!(renderers[0].udn.as_deref(), Some("uuid:RINCON_AAA"));
+        assert_eq!(renderers[0].group_members, vec!["Kitchen"]);
+    }
+
+    #[test]
+    fn display_name_formats() {
+        let mut r = renderer("uuid:RINCON_AAA", "Living Room - Sonos One");
+        assert_eq!(r.display_name(), "Living Room - Sonos One");
+        r.zone_name = Some("Living Room".into());
+        r.group_members = vec!["Kitchen".into()];
+        assert_eq!(r.display_name(), "Living Room + Kitchen");
+        r.group_members = vec!["Kitchen".into(), "Bedroom".into()];
+        assert_eq!(r.display_name(), "Living Room + 2");
+    }
+
+    #[test]
+    fn group_volume_urls_only_for_real_groups() {
+        let mut r = renderer("uuid:RINCON_AAA", "Living Room");
+        // Standalone: plain RenderingControl even though the device
+        // advertises GroupRenderingControl.
+        assert!(r.group_volume_control_url().is_none());
+        assert!(r.volume_event_url().contains("/RenderingControl/"));
+        r.group_members = vec!["Kitchen".into()];
+        assert!(r
+            .group_volume_control_url()
+            .unwrap()
+            .contains("/GroupRenderingControl/"));
+        assert!(r.volume_event_url().contains("/GroupRenderingControl/"));
+    }
+}

--- a/service/src/sonos.rs
+++ b/service/src/sonos.rs
@@ -117,8 +117,12 @@ pub fn parse_zone_group_state(xml: &str) -> Vec<ZoneGroup> {
             let Some(uuid) = m.attribute("UUID") else {
                 continue;
             };
+            // IsZoneBridge covers BRIDGE/BOOST units — no audio output,
+            // never a valid target (SoCo excludes them from visible
+            // zones the same way, independently of Invisible).
             let invisible = m.tag_name().name() == "Satellite"
-                || m.attribute("Invisible").map(|v| v == "1").unwrap_or(false);
+                || m.attribute("Invisible").map(|v| v == "1").unwrap_or(false)
+                || m.attribute("IsZoneBridge").map(|v| v == "1").unwrap_or(false);
             members.push(ZoneMember {
                 uuid: uuid.to_string(),
                 zone_name: m.attribute("ZoneName").unwrap_or("").to_string(),
@@ -397,6 +401,36 @@ mod tests {
         let solo = &renderers[1];
         assert!(solo.group_members.is_empty());
         assert!(!solo.is_group());
+    }
+
+    #[test]
+    fn bridge_units_are_invisible() {
+        // BOOST/BRIDGE: its own single-member group, flagged
+        // IsZoneBridge="1" (SoCo excludes these from visible zones too).
+        let xml = r#"<ZoneGroupState><ZoneGroups>
+<ZoneGroup Coordinator="RINCON_BRIDGE" ID="RINCON_BRIDGE:1">
+  <ZoneGroupMember UUID="RINCON_BRIDGE" Location="http://192.168.1.20:1400/xml/device_description.xml" ZoneName="BOOST" IsZoneBridge="1"/>
+</ZoneGroup>
+</ZoneGroups></ZoneGroupState>"#;
+        let groups = parse_zone_group_state(xml);
+        assert!(groups[0].members[0].invisible);
+        let mut renderers = vec![renderer("uuid:RINCON_BRIDGE", "BOOST")];
+        apply_topology(&mut renderers, &groups, &|_| None);
+        assert!(renderers.is_empty());
+    }
+
+    #[test]
+    fn parses_pre_10_1_shape_without_zonegroups_wrapper() {
+        // Pre-10.1 S1 firmware: ZoneGroup elements sit directly under
+        // ZoneGroupState, no <ZoneGroups> (SoCo's compatibility case).
+        let xml = r#"<ZoneGroupState>
+<ZoneGroup Coordinator="RINCON_AAA" ID="RINCON_AAA:1">
+  <ZoneGroupMember UUID="RINCON_AAA" Location="http://192.168.1.10:1400/xml/device_description.xml" ZoneName="Den"/>
+</ZoneGroup>
+</ZoneGroupState>"#;
+        let groups = parse_zone_group_state(xml);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].members[0].zone_name, "Den");
     }
 
     #[test]

--- a/service/src/ssdp.rs
+++ b/service/src/ssdp.rs
@@ -514,7 +514,10 @@ fn find_header_body_split(buf: &[u8]) -> Option<usize> {
 
 /// If the body starts with a hex chunk-size line (Transfer-Encoding:
 /// chunked), decode the chunks. Otherwise returns the body unchanged.
-fn decode_maybe_chunked(body: &[u8]) -> Vec<u8> {
+/// Shared with upnp.rs's SOAP client — Sonos chunks its HTTP/1.1
+/// responses, and a large GetZoneGroupState body straddles multiple
+/// chunks whose size lines would otherwise corrupt the XML mid-payload.
+pub(crate) fn decode_maybe_chunked(body: &[u8]) -> Vec<u8> {
     // Heuristic: a hex chunk-size line is short, ends with \r\n, and is
     // followed by binary data. If the first \r\n we see is preceded by
     // pure hex digits, treat as chunked.
@@ -562,5 +565,25 @@ impl ToSocketAddrFirst for (&str, u16) {
         addrs
             .next()
             .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::AddrNotAvailable, "no addrs"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dechunks_multi_chunk_body() {
+        // Two chunks whose boundary lands mid-payload — the case a big
+        // GetZoneGroupState response hits: interior chunk-size lines
+        // must not leak into the reassembled XML.
+        let body = b"c\r\n<ZoneGroupSt\r\n4\r\nate>\r\n0\r\n\r\n";
+        assert_eq!(decode_maybe_chunked(body), b"<ZoneGroupState>");
+    }
+
+    #[test]
+    fn plain_body_passes_through() {
+        let body = b"<?xml version=\"1.0\"?><Envelope/>";
+        assert_eq!(decode_maybe_chunked(body), body);
     }
 }

--- a/service/src/ssdp.rs
+++ b/service/src/ssdp.rs
@@ -34,6 +34,21 @@ pub struct Renderer {
     pub av_transport_event_url: Option<String>,
     /// Cached UDN if available.
     pub udn: Option<String>,
+    /// Sonos only: ZoneGroupTopology control URL (GetZoneGroupState).
+    /// Present ⇒ the device participates in Sonos zone grouping.
+    pub zone_group_topology_control_url: Option<String>,
+    /// Sonos only: GroupRenderingControl control URL — group-wide volume
+    /// on the coordinator (SetGroupVolume scales every member).
+    pub group_rendering_control_control_url: Option<String>,
+    /// Sonos only: GroupRenderingControl event URL (GroupVolume NOTIFYs).
+    pub group_rendering_control_event_url: Option<String>,
+    /// Room name from zone topology ("Living Room") — cleaner than the
+    /// device-description friendlyName for group display. Sonos only.
+    pub zone_name: Option<String>,
+    /// Zone names of the OTHER visible members of the group this
+    /// renderer coordinates. Empty ⇒ standalone (or non-Sonos). Filled
+    /// by `sonos::apply_topology`.
+    pub group_members: Vec<String>,
 }
 
 /// Shared discovery state.  The main loop owns one; the SSDP thread
@@ -75,6 +90,23 @@ impl DiscoveryState {
                 return Some(r.clone());
             }
         }
+        // Group-aware match: "--player Kitchen" should find the group
+        // entry that contains Kitchen even though the row is named after
+        // its coordinator.
+        for r in inner.iter() {
+            let zone_hit = r
+                .zone_name
+                .as_deref()
+                .map(|z| z.to_ascii_lowercase().contains(&q))
+                .unwrap_or(false);
+            let member_hit = r
+                .group_members
+                .iter()
+                .any(|m| m.to_ascii_lowercase().contains(&q));
+            if zone_hit || member_hit {
+                return Some(r.clone());
+            }
+        }
         None
     }
 
@@ -105,6 +137,51 @@ impl Renderer {
     /// advertises one, IP literal as fallback.
     pub fn stable_id(&self) -> String {
         self.udn.clone().unwrap_or_else(|| self.ip.to_string())
+    }
+
+    /// True when this renderer coordinates a Sonos group with at least
+    /// one other audible speaker.
+    pub fn is_group(&self) -> bool {
+        !self.group_members.is_empty()
+    }
+
+    /// Name to show the user. Standalone speakers keep their device
+    /// friendlyName; group coordinators use the Sonos convention —
+    /// "Living Room + Kitchen" for a pair, "Living Room + 2" beyond.
+    pub fn display_name(&self) -> String {
+        if !self.is_group() {
+            return self.friendly_name.clone();
+        }
+        let base = self.zone_name.as_deref().unwrap_or(&self.friendly_name);
+        if self.group_members.len() == 1 {
+            format!("{} + {}", base, self.group_members[0])
+        } else {
+            format!("{} + {}", base, self.group_members.len())
+        }
+    }
+
+    /// GroupRenderingControl control URL, but only when volume should
+    /// actually be group-routed (a real multi-speaker group). Standalone
+    /// Sonos zones use plain RenderingControl — identical behavior to
+    /// pre-group builds.
+    pub fn group_volume_control_url(&self) -> Option<&str> {
+        if self.is_group() {
+            self.group_rendering_control_control_url.as_deref()
+        } else {
+            None
+        }
+    }
+
+    /// The event URL our GENA volume-sync subscription should use:
+    /// GroupRenderingControl for a group (GroupVolume events reflect the
+    /// group slider), plain RenderingControl otherwise.
+    pub fn volume_event_url(&self) -> &str {
+        if self.is_group() {
+            if let Some(u) = self.group_rendering_control_event_url.as_deref() {
+                return u;
+            }
+        }
+        &self.rendering_control_event_url
     }
 }
 
@@ -212,6 +289,10 @@ pub fn discover_once(timeout: Duration, iface: Option<Ipv4Addr>) -> Result<Vec<R
         }
     }
 
+    // Sonos: fold zone-group topology in — hides bonded/grouped members,
+    // annotates group coordinators. No-op without Sonos devices.
+    crate::sonos::annotate_with_topology(&mut renderers);
+
     Ok(renderers)
 }
 
@@ -231,7 +312,7 @@ fn extract_header(response: &str, header: &str) -> Option<String> {
     None
 }
 
-fn fetch_and_parse_device(location: &str, timeout: Duration) -> Result<Renderer> {
+pub(crate) fn fetch_and_parse_device(location: &str, timeout: Duration) -> Result<Renderer> {
     let xml = http_get(location, timeout).with_context(|| format!("GET {}", location))?;
     let url = url::Url::parse(location).with_context(|| format!("parse location {}", location))?;
     let base = format!(
@@ -300,6 +381,9 @@ fn parse_device_description(xml: &str, base_url: &str, ip: IpAddr) -> Result<Ren
     let mut av_event: Option<String> = None;
     let mut rc_ctrl: Option<String> = None;
     let mut rc_event: Option<String> = None;
+    let mut zgt_ctrl: Option<String> = None;
+    let mut grc_ctrl: Option<String> = None;
+    let mut grc_event: Option<String> = None;
 
     for svc in device.descendants().filter(|n| n.tag_name().name() == "service") {
         let st = svc
@@ -321,6 +405,13 @@ fn parse_device_description(xml: &str, base_url: &str, ip: IpAddr) -> Result<Ren
         } else if st.contains(":RenderingControl:") {
             rc_ctrl = control.map(|s| s.to_string());
             rc_event = event.map(|s| s.to_string());
+        } else if st.contains(":ZoneGroupTopology:") {
+            // Sonos zone grouping (root device on Sonos hardware).
+            zgt_ctrl = control.map(|s| s.to_string());
+        } else if st.contains(":GroupRenderingControl:") {
+            // Sonos group-wide volume (MediaRenderer sub-device).
+            grc_ctrl = control.map(|s| s.to_string());
+            grc_event = event.map(|s| s.to_string());
         }
     }
 
@@ -337,6 +428,11 @@ fn parse_device_description(xml: &str, base_url: &str, ip: IpAddr) -> Result<Ren
         rendering_control_event_url: absolute_url(base_url, &rc_event),
         av_transport_event_url: av_event.map(|e| absolute_url(base_url, &e)),
         udn,
+        zone_group_topology_control_url: zgt_ctrl.map(|u| absolute_url(base_url, &u)),
+        group_rendering_control_control_url: grc_ctrl.map(|u| absolute_url(base_url, &u)),
+        group_rendering_control_event_url: grc_event.map(|u| absolute_url(base_url, &u)),
+        zone_name: None,
+        group_members: Vec::new(),
     })
 }
 

--- a/service/src/upnp.rs
+++ b/service/src/upnp.rs
@@ -347,15 +347,27 @@ fn soap_post(control_url: &str, soap_action: &str, body: &str) -> Result<String>
 
     let mut buf = Vec::with_capacity(4096);
     stream.read_to_end(&mut buf)?;
-    let text = String::from_utf8_lossy(&buf).to_string();
 
-    let (head, body_part) = text.split_once("\r\n\r\n").unwrap_or((&text[..], ""));
+    // Split head/body on bytes, then peel chunked transfer-encoding if
+    // present. Sonos chunks HTTP/1.1 responses (same behavior ssdp.rs's
+    // http_get dodges by speaking HTTP/1.0); small SOAP replies fit one
+    // chunk and parsed fine by accident, but GetZoneGroupState bodies
+    // run tens of KB and interior chunk-size lines would corrupt the
+    // escaped XML. decode_maybe_chunked is a no-op for plain bodies.
+    let split = buf
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|p| p + 4)
+        .unwrap_or(buf.len());
+    let head = String::from_utf8_lossy(&buf[..split]);
+    let body_part = crate::ssdp::decode_maybe_chunked(&buf[split..]);
+
     let status_line = head.lines().next().unwrap_or("");
     debug!("SOAP {} -> {}", soap_action, status_line);
     if !status_line.contains(" 200 ") {
         return Err(anyhow!("SOAP {} failed: {}", soap_action, status_line));
     }
-    Ok(body_part.to_string())
+    Ok(String::from_utf8_lossy(&body_part).into_owned())
 }
 
 /// Minimal XML attribute / text escape.

--- a/service/src/upnp.rs
+++ b/service/src/upnp.rs
@@ -3,6 +3,9 @@
 //! Actions:
 //!   * AVTransport: SetAVTransportURI, Play, Stop
 //!   * RenderingControl: SetVolume, SetMute, GetVolume, GetMute
+//!   * GroupRenderingControl (Sonos): SetGroupVolume, GetGroupVolume,
+//!     SetGroupMute — group-wide volume, addressed to the coordinator
+//!   * ZoneGroupTopology (Sonos): GetZoneGroupState
 //!
 //! SOAP is just HTTP POST with a specific Content-Type + SOAPAction header
 //! and an envelope-shaped XML body. We hand-roll it over TCP so we don't
@@ -174,6 +177,91 @@ pub fn get_mute(control_url: &str) -> Result<bool> {
     let n = extract_int_tag(&resp, "CurrentMute")
         .ok_or_else(|| anyhow!("CurrentMute missing"))?;
     Ok(n != 0)
+}
+
+/// Set the Sonos group volume (0..=100) via GroupRenderingControl on the
+/// group coordinator. Scales every member proportionally — the same
+/// semantics as the group slider in the Sonos app. Returns 701 when
+/// addressed to a non-coordinator, so callers must route to the
+/// coordinator (ssdp::Renderer::group_volume_control_url does).
+pub fn set_group_volume(control_url: &str, level: u32) -> Result<()> {
+    let level = level.min(100);
+    let body = format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:SetGroupVolume xmlns:u="urn:schemas-upnp-org:service:GroupRenderingControl:1">
+<InstanceID>0</InstanceID>
+<DesiredVolume>{level}</DesiredVolume>
+</u:SetGroupVolume>
+</s:Body>
+</s:Envelope>"#
+    );
+    soap_post(
+        control_url,
+        "urn:schemas-upnp-org:service:GroupRenderingControl:1#SetGroupVolume",
+        &body,
+    )
+    .map(|_| ())
+}
+
+pub fn get_group_volume(control_url: &str) -> Result<u32> {
+    let body = r#"<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:GetGroupVolume xmlns:u="urn:schemas-upnp-org:service:GroupRenderingControl:1">
+<InstanceID>0</InstanceID>
+</u:GetGroupVolume>
+</s:Body>
+</s:Envelope>"#;
+    let resp = soap_post(
+        control_url,
+        "urn:schemas-upnp-org:service:GroupRenderingControl:1#GetGroupVolume",
+        body,
+    )?;
+    extract_int_tag(&resp, "CurrentVolume")
+        .ok_or_else(|| anyhow!("CurrentVolume missing in GetGroupVolume response"))
+}
+
+pub fn set_group_mute(control_url: &str, muted: bool) -> Result<()> {
+    let body = format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:SetGroupMute xmlns:u="urn:schemas-upnp-org:service:GroupRenderingControl:1">
+<InstanceID>0</InstanceID>
+<DesiredMute>{m}</DesiredMute>
+</u:SetGroupMute>
+</s:Body>
+</s:Envelope>"#,
+        m = if muted { 1 } else { 0 }
+    );
+    soap_post(
+        control_url,
+        "urn:schemas-upnp-org:service:GroupRenderingControl:1#SetGroupMute",
+        &body,
+    )
+    .map(|_| ())
+}
+
+/// Fetch the entity-decoded ZoneGroupState XML from a Sonos device's
+/// ZoneGroupTopology service. Parsing lives in `sonos.rs`.
+pub fn get_zone_group_state(control_url: &str) -> Result<String> {
+    let body = r#"<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:GetZoneGroupState xmlns:u="urn:schemas-upnp-org:service:ZoneGroupTopology:1">
+</u:GetZoneGroupState>
+</s:Body>
+</s:Envelope>"#;
+    let resp = soap_post(
+        control_url,
+        "urn:schemas-upnp-org:service:ZoneGroupTopology:1#GetZoneGroupState",
+        body,
+    )?;
+    let inner = crate::gena::find_tag_text(&resp, "ZoneGroupState")
+        .ok_or_else(|| anyhow!("ZoneGroupState missing in response"))?;
+    Ok(crate::gena::xml_unescape(&inner))
 }
 
 /// Build the DIDL-Lite metadata blob for SetAVTransportURI.


### PR DESCRIPTION
Adds Sonos zone-group support to the UPnP path (new `service/src/sonos.rs`).

## What changes

**Discovery** now queries the Sonos `ZoneGroupTopology` service (`GetZoneGroupState`) after each SSDP pass and folds the topology into the renderer list:

- **Grouped speakers show as one entry**, named Sonos-style: "Living Room + Kitchen" for a pair, "Living Room + 2" beyond, with a tooltip listing every member. `--player` also matches zone and group-member names.
- **Non-coordinator members and bonded/audio-less units are hidden**: `Invisible="1"` members (stereo-pair slaves, Subs), `Satellite` children (surrounds), and `IsZoneBridge="1"` units (BRIDGE/BOOST). `SetAVTransportURI` *is* Sonos's group-membership mechanism (`x-rincon:<uuid>` joins a zone to a group), so pointing a member at a normal stream URI changes its membership — members are only reachable through their group's entry, same model as the Sonos app and SoCo's coordinator-only guard.
- **Lost-coordinator recovery:** if a group's coordinator missed the SSDP window but a member answered, the coordinator is fetched from the topology's `Location` URL instead of the whole group vanishing.

**Selection** re-checks topology from the target device right before streaming and redirects to its *current* coordinator, so a list stale by up to one `--ssdp-interval` can't break a group. The id actually bound (the coordinator's) is what gets persisted for auto-reconnect.

**Volume** for group sessions routes through `GroupRenderingControl` on the coordinator: `SetGroupVolume`/`SetGroupMute` scale every member proportionally (the Sonos app's group-slider semantics; error 701 anywhere but the coordinator), the Windows slider is primed from `GetGroupVolume`, and the GENA subscription moves to the flat `GroupVolume`/`GroupMute` events (`parse_rendering_notify` now handles both that shape and the classic `LastChange` one). Standalone zones keep the exact pre-group behavior, including plain `RenderingControl`.

**Latent transport bug fixed along the way:** `soap_post` never de-chunked response bodies. Sonos chunks HTTP/1.1 responses (`ssdp.rs`'s `http_get` already dodges this by speaking HTTP/1.0); small SOAP replies fit one chunk and parsed by accident, but a multi-KB `GetZoneGroupState` response would have had interior chunk-size lines corrupting the escaped XML. The body now goes through `decode_maybe_chunked` (a no-op for plain bodies).

Non-Sonos renderers pass through untouched; every topology call fails open (worst case the list looks like it did before this PR).

## API surface verified against references

Every claim the feature rests on was checked against SoCo (`zonegroupstate.py`, `core.py`), svrooij/sonos-api-docs, and node-sonos-ts:

- `GetZoneGroupState` — no args, answered by any player, output is entity-escaped XML; **both** document shapes handled (S2 wraps `<ZoneGroups>` in `<ZoneGroupState>`; pre-10.1 S1 has `<ZoneGroup>` directly under the root — SoCo's compatibility fallback).
- `ZoneGroupMember` attributes (`UUID` without the `uuid:` prefix, `Location`, `ZoneName`, `Invisible`, `IsZoneBridge`) and nested `Satellite` elements.
- `GroupRenderingControl` action/argument names, coordinator-only 701, and its **flat** evented variables (`GroupVolume`, `GroupMute`, `GroupVolumeChangeable`) vs `RenderingControl`'s `LastChange` — confirmed via svrooij's service docs and node-sonos-ts's typed event map.
- Join/leave mechanics: `SetAVTransportURI` + `x-rincon:<uuid>` joins, `BecomeCoordinatorOfStandaloneGroup` leaves (SoCo's `join()`/`unjoin()`).

The verified facts are recorded in CLAUDE.md (new "Sonos zone groups" section) and TECHNICAL.md.

## Not covered

- The AirPlay entries for individual Sonos speakers are unchanged — AirPlay to any group member already plays group-wide because the Sonos firmware handles that side itself.
- Creating/editing groups from our UI (grouping stays in the Sonos app).
- ZoneGroupTopology GENA eventing (live group-change updates instead of per-scan + on-select checks) — noted in CLAUDE.md as a possible follow-up.

## Verification

- `cargo check` (Linux) and `cargo check --target x86_64-pc-windows-gnu` both clean.
- 101 unit tests pass, including new ones: ZoneGroupState parsing (members, satellites, `Invisible`, `IsZoneBridge`, pre-10.1 shape), member/satellite/bridge hiding + coordinator annotation, missing-coordinator synthesis, non-Sonos pass-through, group display naming, group-vs-standalone volume-URL routing, GroupRenderingControl NOTIFY parsing, and chunked-body reassembly.
- Not yet tested against real grouped Sonos hardware — worth one manual pass with grouped/ungrouped speakers before merging.

Service version 0.6.0 → 0.7.0 (new feature = MINOR per the versioning convention; no driver changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDatEtBff8ce1zsCZfaiLG