### PR TITLE
Once-a-day update check against GitHub Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -351,6 +351,12 @@ jobs:
       - name: Build service (cargo --release)
         shell: pwsh
         working-directory: service
+        env:
+          # Bake the release tag into the exe on tag builds so the in-app
+          # update check (and the version label) use the *installed
+          # release*, not the crate version — the two are independent.
+          # Empty on non-tag builds → dev build → update checks disabled.
+          STS_RELEASE_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && steps.ver.outputs.version || '' }}
         run: cargo build --release
 
       - name: Stage artifacts for installer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,3 +189,16 @@ The user mentioned these but asked NOT to start them now. Pick up when they say:
 - **egui + Windows touchpad scrolling (don't re-learn this).** egui 0.29 exponentially smooths every *Line-unit* wheel event (~90%/100 ms) and only lets sub-8pt *Point-unit* deltas through unsmoothed (its "mac trackpad" bypass in `input_state/mod.rs`). Windows precision touchpads pan via fractional Line-delta `WM_MOUSEWHEEL` events whose decay curve is already smooth, so egui's smoother stacks on the driver's inertia → lag while panning + a rubber-band acceleration/jump at finger-lift. Fix lives in `gui.rs raw_input_hook`: touchpad-shaped events (fractional line deltas, or any within 300 ms of one — flings pass through exact integers) are rewritten to pre-scaled Point events split into sub-8pt chunks so every chunk takes the unsmoothed path; isolated integer notches (real mouse wheels) keep egui's smoothing. The `update()` repaint pump (repaint while `smooth_scroll_delta != 0`) is still needed for the mouse-wheel case in reactive mode. If egui is ever upgraded, re-check `is_smooth` in `input_state` before touching this.
 
 - **App / tray icons must have an active and a non-active variant.** When we eventually replace the procedurally-drawn tray icon with proper artwork (or add an app icon), ship at minimum two states: one for "streaming active" (full color / accent fill / animated sound waves) and one for "idle / no speaker / disabled" (desaturated or outlined). The tray icon is the only persistent UI signal when the window is hidden; a single static icon hides whether the app is actually doing its job. Same applies if we ever ship a taskbar icon. Sizes: 16×16, 24×24, 32×32, 48×48, 256×256 (Windows tray scales down a single 32×32 fine, but the 16×16 master should be hand-tuned — auto-downscale loses detail).
+
+
+## Release version vs crate version (update check)
+
+The service crate version (`service/Cargo.toml`, e.g. 0.6.0) and the GitHub
+release tag (e.g. `v0.1.4`) are **independent**. Anything user-facing or
+compared against GitHub must use `stream_to_speaker::display_version()` /
+`release_version()` (lib.rs), which read `STS_RELEASE_VERSION` — set by
+build.yml's "Build service" step on `v*` tag pushes only (build.rs declares
+`rerun-if-env-changed` so a cached target/ can't ship a stale value). Local
+and non-tag CI builds have no release version: they display the crate
+version and `update_check` never runs. Never compare `CARGO_PKG_VERSION`
+against release tags.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ network as the PC.
 
 Closing the window minimises to the tray; quit from the tray menu.
 
+Once a day the app asks GitHub whether a newer release exists and, if so,
+shows a link to it. Nothing is downloaded or installed by itself. Turn the
+check off under **Advanced** if you'd rather not.
+
 ## CLI flags
 
 ```

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -173,6 +173,24 @@ milliseconds (`airplay_latency_ms` in config.json; default 2000, range
 - Silence injection (default on) replaces silent packets with ~|4|-peak white
   noise after 500 ms so the speaker doesn't treat the stream as dead.
 
+## Update check
+
+`src/update_check.rs`. Once a day (first ~20 s after launch, never on the
+startup path) the app GETs
+`https://api.github.com/repos/Mihonarium/StreamToSpeaker/releases/latest` over
+WinHTTP — the OS HTTPS stack, so the system certificate store and proxy
+apply and no TLS library is bundled. The request carries only a
+`User-Agent` with the app version. If the release tag is newer (strict
+semver) a banner offers the release page; nothing is downloaded or installed
+automatically. "Skip this version" / "Later" and the on/off switch
+(`check_for_updates`, Advanced) persist in `config.json`.
+
+The version compared is the **release tag**, baked in by CI as
+`STS_RELEASE_VERSION` on `v*` tag builds (`release_version()` /
+`display_version()` in `lib.rs`) — not `CARGO_PKG_VERSION`, which is
+versioned independently. A build without it is a dev build: the label shows
+the crate version and update checks are off.
+
 ## HTTP API
 
 `--web` serves a status page at `http://<host>:5901/` plus:

--- a/service/Cargo.lock
+++ b/service/Cargo.lock
@@ -3652,6 +3652,7 @@ dependencies = [
  "raw-window-handle",
  "roxmltree",
  "rsa",
+ "semver",
  "serde",
  "serde_json",
  "sha1",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -40,6 +40,8 @@ percent-encoding = "2"
 # the obvious fit.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Release-tag comparison for the once-a-day update check (src/update_check.rs).
+semver = "1"
 # AirPlay support.
 #
 # mDNS-sd: pure-Rust mDNS browser for `_raop._tcp` / `_airplay._tcp`
@@ -113,6 +115,9 @@ cpal = "0.15"
 # plumbing sane; scoped to just the Media Foundation surface.
 windows = { version = "0.58", features = [
     "Win32_Foundation",
+    # WinHTTP: the OS HTTPS stack for the update check — system cert store
+    # + proxy, no bundled TLS library.
+    "Win32_Networking_WinHttp",
     "Win32_Media_MediaFoundation",
     "Win32_System_Com",
     # WinRT System Media Transport Controls — reads the OS "now playing"

--- a/service/build.rs
+++ b/service/build.rs
@@ -5,6 +5,11 @@
 //! tray icons are set at runtime and are a separate concern — this one is
 //! what the file itself looks like on disk.
 fn main() {
+    // CI bakes the release tag in via STS_RELEASE_VERSION on tag builds
+    // (option_env! in lib.rs). Declare it so a cached target/ from a
+    // non-tag build is never reused with the old (empty) value.
+    println!("cargo:rerun-if-env-changed=STS_RELEASE_VERSION");
+
     #[cfg(windows)]
     {
         const ICON: &str = "../assets/StreamToSpeaker.ico";

--- a/service/src/app.rs
+++ b/service/src/app.rs
@@ -12,6 +12,8 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, AtomicU64, 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crate::update_check::{self, ReleaseInfo};
+
 use crate::airplay::ap2_rtsp::Ap2Rtsp;
 use crate::airplay::ap2_session::DEFAULT_AIRPLAY_PORT;
 use crate::airplay::hap_pairing::PairingCredentials;
@@ -165,6 +167,25 @@ pub struct SpeakerView {
     pub active_id: Option<String>,
 }
 
+/// Result of one update check, for the Help menu's status line.
+#[derive(Clone, Debug)]
+pub enum UpdateOutcome {
+    UpToDate,
+    Available(ReleaseInfo),
+    /// No release tag baked into this exe → nothing to compare against.
+    DevBuild,
+    Failed(String),
+}
+
+/// In-memory update-check state (the persistent part lives in `UserConfig`).
+#[derive(Clone, Debug, Default)]
+pub struct UpdateState {
+    /// A check is in flight (Help menu shows "Checking…").
+    pub checking: bool,
+    /// Outcome + unix time of the most recent check this run.
+    pub last: Option<(UpdateOutcome, u64)>,
+}
+
 pub struct App {
     /// Resolved-at-startup configuration. Immutable after `new`.
     pub config: AppConfig,
@@ -203,6 +224,8 @@ pub struct App {
 
     // ---- Lifecycle ----
     pub shutdown: Arc<AtomicBool>,
+    /// Update-check state; see `update_check` and [`App::spawn_update_checker`].
+    pub update: Mutex<UpdateState>,
 
     // ---- Rescan feedback ----
     /// True while a manual SSDP rescan thread is in flight. Cleared
@@ -336,6 +359,7 @@ impl App {
             packets_published_total: Arc::new(AtomicU64::new(0)),
             started_at: Instant::now(),
             shutdown: Arc::new(AtomicBool::new(false)),
+            update: Mutex::new(UpdateState::default()),
             rescan_in_flight: Arc::new(AtomicBool::new(false)),
             last_rescan_finished_unix: Arc::new(AtomicI64::new(0)),
             last_rescan_count: Arc::new(AtomicUsize::new(0)),
@@ -408,6 +432,181 @@ impl App {
         let mut uc = self.user_config.lock().unwrap();
         uc.donation_prompt_hidden_until = Some(now_unix() + days * 24 * 60 * 60);
         uc.save();
+    }
+
+    // ---- Update check ----------------------------------------------------
+
+    pub fn is_check_for_updates(&self) -> bool {
+        self.user_config.lock().unwrap().check_for_updates
+    }
+
+    pub fn set_check_for_updates(&self, on: bool) {
+        let mut uc = self.user_config.lock().unwrap();
+        if uc.check_for_updates != on {
+            uc.check_for_updates = on;
+            uc.save();
+        }
+    }
+
+    pub fn update_state(&self) -> UpdateState {
+        self.update.lock().unwrap().clone()
+    }
+
+    /// The newer release the banner should offer right now, if any. Works
+    /// off the cached last result so it is correct from the first frame.
+    pub fn update_banner(&self) -> Option<ReleaseInfo> {
+        let current = update_check::current_version()?;
+        let uc = self.user_config.lock().unwrap();
+        let tag = uc.update_latest_tag.as_deref()?;
+        let version = update_check::banner_candidate(
+            &current,
+            tag,
+            uc.update_skipped_tag.as_deref(),
+            uc.update_banner_hidden_until,
+            now_unix(),
+        )?;
+        Some(ReleaseInfo {
+            tag: tag.to_string(),
+            version,
+            url: uc
+                .update_latest_url
+                .clone()
+                .unwrap_or_else(|| update_check::RELEASES_PAGE.to_string()),
+            installer_url: None,
+        })
+    }
+
+    /// "Skip this version": never offer `tag` again (a later one still shows).
+    pub fn skip_update(&self, tag: &str) {
+        let mut uc = self.user_config.lock().unwrap();
+        uc.update_skipped_tag = Some(tag.to_string());
+        uc.save();
+    }
+
+    /// "Later": hide the banner for `days`.
+    pub fn snooze_update_banner(&self, days: u64) {
+        let mut uc = self.user_config.lock().unwrap();
+        uc.update_banner_hidden_until = Some(now_unix() + days * 24 * 60 * 60);
+        uc.save();
+    }
+
+    fn update_check_due(&self) -> bool {
+        let uc = self.user_config.lock().unwrap();
+        if !uc.check_for_updates {
+            return false;
+        }
+        match uc.update_last_check_unix {
+            None => true,
+            Some(t) => now_unix().saturating_sub(t) >= update_check::CHECK_INTERVAL.as_secs(),
+        }
+    }
+
+    /// One blocking check (call off the UI thread). `manual` bypasses the
+    /// enable switch and the daily cadence; a dev build never checks.
+    pub fn run_update_check(&self, manual: bool) {
+        let finish = |outcome: UpdateOutcome| {
+            let mut st = self.update.lock().unwrap();
+            st.checking = false;
+            st.last = Some((outcome, now_unix()));
+        };
+        let Some(current) = update_check::current_version() else {
+            finish(UpdateOutcome::DevBuild);
+            return;
+        };
+        if !manual && !self.is_check_for_updates() {
+            self.update.lock().unwrap().checking = false;
+            return;
+        }
+        self.update.lock().unwrap().checking = true;
+        let result = update_check::fetch_latest_release();
+        let now = now_unix();
+        let outcome = match result {
+            Ok(rel) => {
+                {
+                    let mut uc = self.user_config.lock().unwrap();
+                    uc.update_last_check_unix = Some(now);
+                    uc.update_latest_tag = Some(rel.tag.clone());
+                    uc.update_latest_url = Some(rel.url.clone());
+                    uc.save();
+                }
+                if update_check::is_newer(&rel.version, &current) {
+                    log::info!(
+                        "update available: {} (this is v{}) — {}",
+                        rel.tag,
+                        crate::display_version(),
+                        rel.url
+                    );
+                    UpdateOutcome::Available(rel)
+                } else {
+                    log::info!("update check: v{} is the latest release", crate::display_version());
+                    UpdateOutcome::UpToDate
+                }
+            }
+            Err(e) => {
+                // Stamp the attempt so an offline machine retries once a
+                // day, not every hour; the cached latest (if any) still
+                // drives the banner.
+                let mut uc = self.user_config.lock().unwrap();
+                uc.update_last_check_unix = Some(now);
+                uc.save();
+                log::warn!("update check failed: {:#}", e);
+                UpdateOutcome::Failed(format!("{e:#}"))
+            }
+        };
+        finish(outcome);
+    }
+
+    /// Sleep `d` in slices, returning false early if shutdown began.
+    fn sleep_unless_shutdown(&self, d: Duration) -> bool {
+        let end = Instant::now() + d;
+        while Instant::now() < end {
+            if self.is_shutting_down() {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(250));
+        }
+        true
+    }
+
+    /// Background once-a-day update check: first attempt ~20 s after
+    /// launch (never on the startup path), then whenever 24 h have passed
+    /// since the last attempt, re-evaluated hourly. Everything it does is
+    /// gated by `check_for_updates`; a dev build is a no-op.
+    pub fn spawn_update_checker(self: &Arc<Self>) {
+        let app = self.clone();
+        std::thread::Builder::new()
+            .name("stream-to-speaker-update-check".into())
+            .spawn(move || {
+                if !app.sleep_unless_shutdown(update_check::STARTUP_DELAY) {
+                    return;
+                }
+                loop {
+                    if app.update_check_due() {
+                        app.run_update_check(false);
+                    }
+                    if !app.sleep_unless_shutdown(Duration::from_secs(60 * 60)) {
+                        return;
+                    }
+                }
+            })
+            .ok();
+    }
+
+    /// Help menu "Check for updates now": one manual check on a worker
+    /// thread. `checking` is set here so the menu reflects it immediately.
+    pub fn check_for_updates_now(self: &Arc<Self>) {
+        {
+            let mut st = self.update.lock().unwrap();
+            if st.checking {
+                return;
+            }
+            st.checking = true;
+        }
+        let app = self.clone();
+        std::thread::Builder::new()
+            .name("stream-to-speaker-update-check-manual".into())
+            .spawn(move || app.run_update_check(true))
+            .ok();
     }
 
     /// Undo the onboarding dismissal (Help menu → "Show getting-

--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -1234,6 +1234,7 @@ impl eframe::App for StreamToSpeakerApp {
                             self.show_status_banner(ui, &p);
                             banner_bottom_px = ui.cursor().top();
                             self.show_error_banner(ui, &p);
+                            self.show_update_banner(ui, &p);
                             self.show_donation_banner(ui, &p);
                             ui.add_space(sp::M);
                             // Show onboarding regardless of whether a
@@ -1466,7 +1467,7 @@ impl StreamToSpeakerApp {
                                 .color(p.text_primary),
                         );
                         ui.label(
-                            egui::RichText::new(format!("v{}", env!("CARGO_PKG_VERSION")))
+                            egui::RichText::new(format!("v{}", crate::display_version()))
                                 .size(12.0)
                                 .color(p.text_tertiary),
                         );
@@ -1512,7 +1513,7 @@ impl StreamToSpeakerApp {
                 ui.label(
                     egui::RichText::new(format!(
                         "Stream To Speaker v{}",
-                        env!("CARGO_PKG_VERSION")
+                        crate::display_version()
                     ))
                     .strong()
                     .color(p.text_primary),
@@ -1534,6 +1535,16 @@ impl StreamToSpeakerApp {
                         "https://github.com/Mihonarium/StreamToSpeaker/issues/new",
                     );
                     ui.memory_mut(|m| m.close_popup());
+                }
+                ui.separator();
+                let (status, busy) = self.update_status_line();
+                ui.label(
+                    egui::RichText::new(status)
+                        .size(12.0)
+                        .color(p.text_secondary),
+                );
+                if !busy && ui.button("Check for updates now").clicked() {
+                    self.app.check_for_updates_now();
                 }
                 // "Show getting started" — undo onboarding dismissal
                 // so it appears on the next paint (m20). Useful for
@@ -2068,6 +2079,111 @@ impl StreamToSpeakerApp {
     /// never the same nag twice in one week. Deliberately a quiet strip
     /// rather than a modal — it must never stand between the user and
     /// the speaker list.
+    /// "A newer version is available" strip. Same shape as the donation
+    /// banner; driven by the cached update-check result so it's present
+    /// from the first frame after launch. Never installs anything — the
+    /// primary action opens the release page in the browser.
+    fn show_update_banner(&mut self, ui: &mut egui::Ui, p: &Palette) {
+        let Some(rel) = self.app.update_banner() else {
+            return;
+        };
+        ui.add_space(sp::XS);
+        egui::Frame::none()
+            .fill(p.accent_subtle)
+            .rounding(RADIUS_SURFACE)
+            .inner_margin(egui::Margin::symmetric(sp::M, sp::S))
+            .show(ui, |ui| {
+                // Three buttons need ~330 px; stack below that so the
+                // message wraps on its own line instead of sliding under
+                // them (see show_donation_banner).
+                let stacked = ui.available_width() < 640.0;
+                let msg = egui::RichText::new(format!(
+                    "⬆  Stream To Speaker {} is available — you have v{}.",
+                    rel.tag,
+                    crate::display_version()
+                ))
+                .color(p.text_on_accent_subtle);
+
+                let buttons = |ui: &mut egui::Ui| -> (bool, bool, bool) {
+                    let (mut download, mut skip, mut later) = (false, false, false);
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            later = secondary_button(ui, p, "Later", 72.0)
+                                .on_hover_text("Hide this for three days.")
+                                .clicked();
+                            skip = secondary_button(ui, p, "Skip this version", 130.0)
+                                .on_hover_text(
+                                    "Don't mention this version again. A later one will still show.",
+                                )
+                                .clicked();
+                            download = primary_button(ui, p, "Download", 100.0)
+                                .on_hover_text(
+                                    "Opens the release page on GitHub in your browser. \
+                                     Run the installer from there — nothing is installed \
+                                     automatically.",
+                                )
+                                .clicked();
+                        },
+                    );
+                    (download, skip, later)
+                };
+
+                let (download, skip, later) = if stacked {
+                    let mut clicks = (false, false, false);
+                    ui.vertical(|ui| {
+                        ui.label(msg);
+                        ui.add_space(sp::S);
+                        clicks = buttons(ui);
+                    });
+                    clicks
+                } else {
+                    let mut clicks = (false, false, false);
+                    ui.horizontal(|ui| {
+                        ui.label(msg);
+                        clicks = buttons(ui);
+                    });
+                    clicks
+                };
+
+                if download {
+                    let _ = open_url(&rel.url);
+                }
+                if skip {
+                    self.app.skip_update(&rel.tag);
+                }
+                if later {
+                    self.app.snooze_update_banner(3);
+                }
+            });
+    }
+
+    /// One-line update status for the Help menu, plus whether the
+    /// "Check now" button should be hidden (dev build / check in flight).
+    fn update_status_line(&self) -> (String, bool) {
+        use crate::app::UpdateOutcome;
+        if crate::release_version().is_none() {
+            return ("Development build — update checks are off.".into(), true);
+        }
+        let st = self.app.update_state();
+        if st.checking {
+            return ("Checking for updates…".into(), true);
+        }
+        let line = match st.last {
+            None if self.app.is_check_for_updates() => {
+                "Updates: not checked yet since launch.".to_string()
+            }
+            None => "Automatic update checks are off (Advanced).".to_string(),
+            Some((UpdateOutcome::UpToDate, _)) => "You have the latest version.".to_string(),
+            Some((UpdateOutcome::Available(r), _)) => format!("{} is available.", r.tag),
+            Some((UpdateOutcome::DevBuild, _)) => {
+                "Development build — update checks are off.".to_string()
+            }
+            Some((UpdateOutcome::Failed(e), _)) => format!("Couldn't check for updates: {e}"),
+        };
+        (line, false)
+    }
+
     fn show_donation_banner(&mut self, ui: &mut egui::Ui, p: &Palette) {
         if !self.app.should_show_donation_prompt() {
             return;
@@ -2683,6 +2799,21 @@ impl StreamToSpeakerApp {
                     uc.save();
                 }
             }
+
+            ui.add_space(sp::S);
+
+            let mut check_updates = self.app.is_check_for_updates();
+            advanced_row(
+                ui,
+                p,
+                "Check for updates",
+                "Asks GitHub once a day whether a newer version exists. Nothing installs by itself.",
+                "Once a day the app fetches the latest release entry from github.com — a plain web request carrying only the app version, so GitHub sees your IP address as any website would. If a newer version exists, a strip at the top offers a link to the download page; nothing is downloaded or installed automatically. You can also check on demand from the ? menu. Development builds never check.",
+                |ui| {
+                    ui.checkbox(&mut check_updates, "Check for updates once a day");
+                },
+            );
+            self.app.set_check_for_updates(check_updates);
 
             ui.add_space(sp::S);
 

--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -1234,8 +1234,11 @@ impl eframe::App for StreamToSpeakerApp {
                             self.show_status_banner(ui, &p);
                             banner_bottom_px = ui.cursor().top();
                             self.show_error_banner(ui, &p);
-                            self.show_update_banner(ui, &p);
-                            self.show_donation_banner(ui, &p);
+                            // One ask at a time: an available update
+                            // outranks the donation strip.
+                            if !self.show_update_banner(ui, &p) {
+                                self.show_donation_banner(ui, &p);
+                            }
                             ui.add_space(sp::M);
                             // Show onboarding regardless of whether a
                             // speaker is currently bound, until the
@@ -1388,6 +1391,44 @@ fn window_close_cursor(ctx: &egui::Context, window_rect: egui::Rect, inner_margi
 
 /// Primary button — solid accent fill, white-on-accent text. Use for the
 /// main action of each area (Enable, Minimise to tray, Apply, etc.).
+/// A notice strip's content row: a message with right-aligned actions,
+/// laid out so the message can never run under the buttons. The buttons
+/// are placed first (right-to-left), then the message wraps in whatever
+/// width is left; if that would be too narrow to read, the row stacks —
+/// message on top, buttons right-aligned beneath. `buttons_w` is the
+/// buttons' total width including gaps (the caller knows it from the min
+/// widths it passes to the button helpers).
+///
+/// Why: a label added *before* a right-to-left button group claims the
+/// row at its full single-line width — labels don't wrap inside
+/// horizontal layouts — so past a certain window width the buttons were
+/// painted straight over the text. A fixed "stack below N px" threshold
+/// only moved that collision to a different window width (the donation
+/// strip overlapped at the default 720 px window).
+fn notice_row(
+    ui: &mut egui::Ui,
+    msg: egui::RichText,
+    buttons_w: f32,
+    buttons: impl FnOnce(&mut egui::Ui),
+) {
+    const MIN_TEXT_W: f32 = 240.0;
+    if ui.available_width() - buttons_w - sp::S < MIN_TEXT_W {
+        ui.vertical(|ui| {
+            ui.add(egui::Label::new(msg).wrap());
+            ui.add_space(sp::S);
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), buttons);
+        });
+    } else {
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            buttons(ui);
+            ui.add_space(sp::S);
+            ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                ui.add(egui::Label::new(msg).wrap());
+            });
+        });
+    }
+}
+
 fn primary_button(ui: &mut egui::Ui, p: &Palette, label: &str, min_width: f32) -> egui::Response {
     let btn = egui::Button::new(
         egui::RichText::new(label)
@@ -1510,6 +1551,9 @@ impl StreamToSpeakerApp {
             egui::PopupCloseBehavior::CloseOnClickOutside,
             |ui| {
                 ui.set_min_width(240.0);
+                // Bounded so a long status line wraps instead of
+                // widening the popup off-screen.
+                ui.set_max_width(360.0);
                 ui.label(
                     egui::RichText::new(format!(
                         "Stream To Speaker v{}",
@@ -1659,9 +1703,10 @@ impl StreamToSpeakerApp {
                 (
                     "3",
                     "Adjust the latency if audio drifts",
-                    "If audio lags the picture, use the Trim buttons. If it \
-                     glitches, use the Pad buttons. Resync gives an instant \
-                     fix at the cost of a brief audio click.",
+                    "If audio lags the picture, use −25 / −100 ms in the \
+                     Latency card. If it glitches or drops out, use \
+                     +25 / +100 ms. Resync speaker restarts the connection — \
+                     an instant fix at the cost of a brief click.",
                 ),
             ];
 
@@ -1786,25 +1831,14 @@ impl StreamToSpeakerApp {
                     ui.label(egui::RichText::new(icon).color(accent).size(34.0).strong());
                     ui.add_space(sp::S);
 
-                    ui.vertical(|ui| {
-                        ui.add_space(2.0);
-                        ui.label(
-                            egui::RichText::new(headline)
-                                .size(16.0)
-                                .strong()
-                                .color(p.text_primary),
-                        );
-                        ui.label(
-                            egui::RichText::new(detail)
-                                .size(12.0)
-                                .color(p.text_secondary),
-                        );
-                    });
-
-                    if let (Some(label), Some(tip)) = (btn_label, btn_tip) {
-                        ui.with_layout(
-                            egui::Layout::right_to_left(egui::Align::Center),
-                            |ui| {
+                    // Buttons first (right-aligned), the text column in
+                    // whatever is left, wrapping — so a long speaker name
+                    // folds onto a second line instead of running under
+                    // the buttons (the notice_row rule).
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            if let (Some(label), Some(tip)) = (btn_label, btn_tip) {
                                 ui.vertical(|ui| {
                                     ui.with_layout(
                                         egui::Layout::right_to_left(egui::Align::Center),
@@ -1865,9 +1899,31 @@ impl StreamToSpeakerApp {
                                         );
                                     }
                                 });
-                            },
-                        );
-                    }
+                                ui.add_space(sp::S);
+                            }
+
+                            ui.with_layout(egui::Layout::top_down(egui::Align::Min), |ui| {
+                                ui.add_space(2.0);
+                                ui.add(
+                                    egui::Label::new(
+                                        egui::RichText::new(headline)
+                                            .size(16.0)
+                                            .strong()
+                                            .color(p.text_primary),
+                                    )
+                                    .wrap(),
+                                );
+                                ui.add(
+                                    egui::Label::new(
+                                        egui::RichText::new(detail)
+                                            .size(12.0)
+                                            .color(p.text_secondary),
+                                    )
+                                    .wrap(),
+                                );
+                            });
+                        },
+                    );
                 });
             });
 
@@ -1925,23 +1981,10 @@ impl StreamToSpeakerApp {
                     ui.painter().circle_filled(rect.center(), 5.0, accent);
                     ui.add_space(sp::S);
 
-                    ui.label(
-                        egui::RichText::new(&current.friendly_name)
-                            .size(12.0)
-                            .strong()
-                            .color(p.text_primary),
-                    );
-                    ui.label(
-                        egui::RichText::new("·")
-                            .size(12.0)
-                            .color(p.text_tertiary),
-                    );
-                    ui.label(
-                        egui::RichText::new(status_text)
-                            .size(12.0)
-                            .color(p.text_secondary),
-                    );
-
+                    // Button first, then the text in what is left, with the
+                    // speaker name truncated (an ellipsis, not a wrap — this
+                    // bar is one line by design) so a long name can't run
+                    // under the button.
                     ui.with_layout(
                         egui::Layout::right_to_left(egui::Align::Center),
                         |ui| {
@@ -1968,6 +2011,36 @@ impl StreamToSpeakerApp {
                                     ));
                                 }
                             }
+                            ui.add_space(sp::S);
+                            ui.with_layout(
+                                egui::Layout::left_to_right(egui::Align::Center),
+                                |ui| {
+                                    // Leave room for " · Streaming" after the name.
+                                    let name_w = (ui.available_width() - 96.0).max(60.0);
+                                    ui.scope(|ui| {
+                                        ui.set_max_width(name_w);
+                                        ui.add(
+                                            egui::Label::new(
+                                                egui::RichText::new(&current.friendly_name)
+                                                    .size(12.0)
+                                                    .strong()
+                                                    .color(p.text_primary),
+                                            )
+                                            .truncate(),
+                                        );
+                                    });
+                                    ui.label(
+                                        egui::RichText::new("·")
+                                            .size(12.0)
+                                            .color(p.text_tertiary),
+                                    );
+                                    ui.label(
+                                        egui::RichText::new(status_text)
+                                            .size(12.0)
+                                            .color(p.text_secondary),
+                                    );
+                                },
+                            );
                         },
                     );
                 });
@@ -1997,29 +2070,21 @@ impl StreamToSpeakerApp {
                             .strong(),
                     );
                     ui.add_space(sp::XS);
-                    // Lay Dismiss out FIRST, then the message into what is
-                    // left. Adding the message first let it claim the whole
-                    // row, so the button — which has a transparent fill —
-                    // was drawn on top of the words. A long error message
-                    // now wraps instead of colliding.
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
+                    // Dismiss is laid out first and the message wraps into
+                    // what is left (notice_row), so a long error can't run
+                    // under the button.
+                    let mut dismiss = false;
+                    notice_row(
+                        ui,
+                        egui::RichText::new(&msg).color(p.text_primary),
+                        80.0,
                         |ui| {
-                            if link_button(ui, p, "Dismiss", 80.0).clicked() {
-                                self.app.dismiss_error();
-                            }
-                            ui.add_space(sp::S);
-                            ui.with_layout(
-                                egui::Layout::left_to_right(egui::Align::Center),
-                                |ui| {
-                                    ui.label(
-                                        egui::RichText::new(&msg)
-                                            .color(p.text_primary),
-                                    );
-                                },
-                            );
+                            dismiss = link_button(ui, p, "Dismiss", 80.0).clicked();
                         },
                     );
+                    if dismiss {
+                        self.app.dismiss_error();
+                    }
                 });
             });
     }
@@ -2074,18 +2139,14 @@ impl StreamToSpeakerApp {
         }
     }
 
-    /// Donation ask. Shown on launch until the user either follows the
-    /// link or asks to be reminded later; both choices persist, so it is
-    /// never the same nag twice in one week. Deliberately a quiet strip
-    /// rather than a modal — it must never stand between the user and
-    /// the speaker list.
-    /// "A newer version is available" strip. Same shape as the donation
-    /// banner; driven by the cached update-check result so it's present
-    /// from the first frame after launch. Never installs anything — the
-    /// primary action opens the release page in the browser.
-    fn show_update_banner(&mut self, ui: &mut egui::Ui, p: &Palette) {
+    /// "A newer version is available" strip. Driven by the cached
+    /// update-check result so it's present from the first frame after
+    /// launch. Never installs anything — the primary action opens the
+    /// release page in the browser. Returns whether it was shown, so the
+    /// caller can hold the donation strip back: one ask at a time.
+    fn show_update_banner(&mut self, ui: &mut egui::Ui, p: &Palette) -> bool {
         let Some(rel) = self.app.update_banner() else {
-            return;
+            return false;
         };
         ui.add_space(sp::XS);
         egui::Frame::none()
@@ -2093,59 +2154,30 @@ impl StreamToSpeakerApp {
             .rounding(RADIUS_SURFACE)
             .inner_margin(egui::Margin::symmetric(sp::M, sp::S))
             .show(ui, |ui| {
-                // Three buttons need ~330 px; stack below that so the
-                // message wraps on its own line instead of sliding under
-                // them (see show_donation_banner).
-                let stacked = ui.available_width() < 640.0;
                 let msg = egui::RichText::new(format!(
                     "⬆  Stream To Speaker {} is available — you have v{}.",
                     rel.tag,
                     crate::display_version()
                 ))
                 .color(p.text_on_accent_subtle);
-
-                let buttons = |ui: &mut egui::Ui| -> (bool, bool, bool) {
-                    let (mut download, mut skip, mut later) = (false, false, false);
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            later = secondary_button(ui, p, "Later", 72.0)
-                                .on_hover_text("Hide this for three days.")
-                                .clicked();
-                            skip = secondary_button(ui, p, "Skip this version", 130.0)
-                                .on_hover_text(
-                                    "Don't mention this version again. A later one will still show.",
-                                )
-                                .clicked();
-                            download = primary_button(ui, p, "Download", 100.0)
-                                .on_hover_text(
-                                    "Opens the release page on GitHub in your browser. \
-                                     Run the installer from there — nothing is installed \
-                                     automatically.",
-                                )
-                                .clicked();
-                        },
-                    );
-                    (download, skip, later)
-                };
-
-                let (download, skip, later) = if stacked {
-                    let mut clicks = (false, false, false);
-                    ui.vertical(|ui| {
-                        ui.label(msg);
-                        ui.add_space(sp::S);
-                        clicks = buttons(ui);
-                    });
-                    clicks
-                } else {
-                    let mut clicks = (false, false, false);
-                    ui.horizontal(|ui| {
-                        ui.label(msg);
-                        clicks = buttons(ui);
-                    });
-                    clicks
-                };
-
+                let (mut download, mut skip, mut later) = (false, false, false);
+                notice_row(ui, msg, 100.0 + 130.0 + 72.0 + 2.0 * sp::XS, |ui| {
+                    later = secondary_button(ui, p, "Later", 72.0)
+                        .on_hover_text("Hide this for three days.")
+                        .clicked();
+                    skip = secondary_button(ui, p, "Skip this version", 130.0)
+                        .on_hover_text(
+                            "Don't mention this version again. A later one will still show.",
+                        )
+                        .clicked();
+                    download = primary_button(ui, p, "Download", 100.0)
+                        .on_hover_text(
+                            "Opens the release page on GitHub in your browser. \
+                             Run the installer from there — nothing is installed \
+                             automatically.",
+                        )
+                        .clicked();
+                });
                 if download {
                     let _ = open_url(&rel.url);
                 }
@@ -2156,6 +2188,7 @@ impl StreamToSpeakerApp {
                     self.app.snooze_update_banner(3);
                 }
             });
+        true
     }
 
     /// One-line update status for the Help menu, plus whether the
@@ -2179,11 +2212,20 @@ impl StreamToSpeakerApp {
             Some((UpdateOutcome::DevBuild, _)) => {
                 "Development build — update checks are off.".to_string()
             }
-            Some((UpdateOutcome::Failed(e), _)) => format!("Couldn't check for updates: {e}"),
+            Some((UpdateOutcome::Failed(e), _)) => {
+                // One line of reason is plenty in a popup; the log has it all.
+                let e: String = e.chars().take(90).collect();
+                format!("Couldn't check for updates: {e}")
+            }
         };
         (line, false)
     }
 
+    /// Donation ask. Shown on launch until the user either follows the
+    /// link or asks to be reminded later; both choices persist, so it is
+    /// never the same nag twice in one week. Deliberately a quiet strip
+    /// rather than a modal — it must never stand between the user and
+    /// the speaker list.
     fn show_donation_banner(&mut self, ui: &mut egui::Ui, p: &Palette) {
         if !self.app.should_show_donation_prompt() {
             return;
@@ -2194,55 +2236,23 @@ impl StreamToSpeakerApp {
             .rounding(RADIUS_SURFACE)
             .inner_margin(egui::Margin::symmetric(sp::M, sp::S))
             .show(ui, |ui| {
-                // Buttons need ~200 px. On a narrow window the message used
-                // to share their row and slide underneath them (labels don't
-                // wrap inside a horizontal layout), so below the threshold
-                // the strip stacks: message on its own line — where it wraps
-                // — and the buttons right-aligned beneath it.
-                let stacked = ui.available_width() < 540.0;
                 let msg = egui::RichText::new(
                     "☕  Stream To Speaker is free and open source. \
                      Donate to support its development.",
                 )
                 .color(p.text_on_accent_subtle);
-
-                let buttons = |ui: &mut egui::Ui| -> (bool, bool) {
-                    let mut donate = false;
-                    let mut later = false;
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            later = secondary_button(ui, p, "Not now", 84.0)
-                                .on_hover_text("Hide this for a week.")
-                                .clicked();
-                            donate = primary_button(ui, p, "Donate", 96.0)
-                                .on_hover_text(
-                                    "Opens buymeacoffee.com/ms00 in your browser. \
-                                     Any amount, one-off or monthly.",
-                                )
-                                .clicked();
-                        },
-                    );
-                    (donate, later)
-                };
-
-                let (donate, later) = if stacked {
-                    let mut clicks = (false, false);
-                    ui.vertical(|ui| {
-                        ui.label(msg);
-                        ui.add_space(sp::S);
-                        clicks = buttons(ui);
-                    });
-                    clicks
-                } else {
-                    let mut clicks = (false, false);
-                    ui.horizontal(|ui| {
-                        ui.label(msg);
-                        clicks = buttons(ui);
-                    });
-                    clicks
-                };
-
+                let (mut donate, mut later) = (false, false);
+                notice_row(ui, msg, 96.0 + 84.0 + sp::XS, |ui| {
+                    later = secondary_button(ui, p, "Not now", 84.0)
+                        .on_hover_text("Hide this for a week.")
+                        .clicked();
+                    donate = primary_button(ui, p, "Donate", 96.0)
+                        .on_hover_text(
+                            "Opens buymeacoffee.com/ms00 in your browser. \
+                             Any amount, one-off or monthly.",
+                        )
+                        .clicked();
+                });
                 if later {
                     self.app.snooze_donation_prompt(7);
                 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -18,6 +18,7 @@ pub mod sine_source;
 pub mod qpc;
 pub mod picker;
 pub mod user_config;
+pub mod update_check;
 pub mod now_playing;
 #[cfg(windows)]
 pub mod wasapi_source;
@@ -37,6 +38,24 @@ pub mod endpoint_name;
 pub const PRODUCT_NAME: &str = "Stream To Speaker";
 /// Short slug used in user agents.
 pub const PRODUCT_UA: &str = "stream-to-speaker/0.1";
+
+/// Release version CI bakes in on tag builds (`STS_RELEASE_VERSION` = the
+/// git tag minus its `v`, see build.yml). Unset for local/dev builds.
+const RELEASE_VERSION_ENV: Option<&str> = option_env!("STS_RELEASE_VERSION");
+
+/// The release this exe was built for, or `None` for a dev build. NB the
+/// crate version (`CARGO_PKG_VERSION`) is *not* the release version — the
+/// two are versioned independently — so anything user-facing or
+/// comparable against GitHub must use this.
+pub fn release_version() -> Option<&'static str> {
+    RELEASE_VERSION_ENV.filter(|s| !s.trim().is_empty())
+}
+
+/// Version to show people: the release tag on release builds, else the
+/// crate version (dev builds).
+pub fn display_version() -> &'static str {
+    release_version().unwrap_or(env!("CARGO_PKG_VERSION"))
+}
 
 /// Wire format: only L16 PCM, 44.1 kHz, stereo in v1.
 pub const WIRE_SAMPLE_RATE: u32 = 44_100;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -197,7 +197,7 @@ fn main() {
     // failure between them was invisible because log::error! was a
     // no-op until builder.init() landed.
     init_logging(&cli);
-    info!("{} v{} entering main()", PRODUCT_NAME, env!("CARGO_PKG_VERSION"));
+    info!("{} v{} entering main()", PRODUCT_NAME, stream_to_speaker::display_version());
 
     // Crash visibility. With windows_subsystem="windows" the default
     // panic handler writes to stderr — which is a dead handle in GUI
@@ -300,7 +300,7 @@ fn write_startup_tombstone() {
                 f,
                 "{}\tv{}\tmain() entered",
                 now,
-                env!("CARGO_PKG_VERSION")
+                stream_to_speaker::display_version()
             );
         }
     }
@@ -439,7 +439,7 @@ fn raise_existing_window() {
 }
 
 fn run(cli: Cli) -> Result<()> {
-    info!("{} v{}", PRODUCT_NAME, env!("CARGO_PKG_VERSION"));
+    info!("{} v{}", PRODUCT_NAME, stream_to_speaker::display_version());
 
     // --list-speakers short-circuit
     if cli.list_speakers {
@@ -474,6 +474,10 @@ fn run(cli: Cli) -> Result<()> {
     // Auto-reconnect watchdog — replaces a dropped AirPlay session with a
     // fresh one so the UI never shows a zombie "streaming" state.
     app.spawn_reconnect_watchdog();
+
+    // Once-a-day "newer release on GitHub?" check (Advanced toggle; a
+    // dev build without a baked release tag never checks).
+    app.spawn_update_checker();
 
     // Now-playing metadata forwarder (off by default; pushes the OS's
     // current track to the speaker when enabled).

--- a/service/src/update_check.rs
+++ b/service/src/update_check.rs
@@ -1,0 +1,371 @@
+//! Once-a-day "is there a newer release?" check against GitHub.
+//!
+//! The boring, well-trodden shape for a desktop app:
+//!
+//! - **Source of truth:** the GitHub Releases API,
+//!   `GET /repos/<owner>/<repo>/releases/latest`. It returns the newest
+//!   *published, non-prerelease* release, so drafts and the `driver-v*`
+//!   prerelease entries are excluded server-side (and rejected again here,
+//!   defensively).
+//! - **Version compared:** [`crate::release_version`] — the git tag CI
+//!   baked into this exe via `STS_RELEASE_VERSION` — never
+//!   `CARGO_PKG_VERSION`. The crate version and the release tag are
+//!   independent (crate 0.6.0 vs tag v0.1.4 when this was written), so
+//!   comparing the crate version would report "up to date" forever. A
+//!   build without a baked tag is a dev build and never checks.
+//! - **Transport:** WinHTTP, the OS HTTPS stack — system certificate
+//!   store, system proxy settings and TLS policy apply, and we ship no
+//!   TLS library of our own. There is deliberately no non-Windows fetch:
+//!   the product is Windows-only, and everything *except* the fetch is
+//!   unit-tested cross-platform.
+//! - **Cadence:** one check ~20 s after launch (never on the startup
+//!   path), then at most once per 24 h, persisted across launches. One
+//!   unauthenticated request a day is nothing against GitHub's 60/h
+//!   per-IP limit, so there is no ETag / conditional-request machinery.
+//! - **Privacy:** a plain GET carrying only a `User-Agent` with the app
+//!   version; GitHub sees the IP address as for any web request. Off
+//!   switch in Advanced (`check_for_updates`).
+//! - **No auto-download, no auto-install.** The app only *tells* the user
+//!   and links to the release page; the installer (which also installs a
+//!   driver) is run by the user. Executing something we fetched ourselves
+//!   would need signature verification we don't have.
+
+use anyhow::{bail, Context, Result};
+use std::time::Duration;
+
+/// GitHub `owner/repo`.
+pub const REPO: &str = "Mihonarium/StreamToSpeaker";
+/// API host for [`API_PATH`].
+pub const API_HOST: &str = "api.github.com";
+/// The "latest release" endpoint (published, non-prerelease only).
+pub const API_PATH: &str = "/repos/Mihonarium/StreamToSpeaker/releases/latest";
+/// Human landing page, used when a release carries no `html_url`.
+pub const RELEASES_PAGE: &str = "https://github.com/Mihonarium/StreamToSpeaker/releases/latest";
+/// The stable-named installer asset CI attaches to every release.
+pub const INSTALLER_ASSET: &str = "StreamToSpeakerSetup.exe";
+/// Minimum spacing between automatic checks.
+pub const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+/// Wait after launch before the first automatic check.
+pub const STARTUP_DELAY: Duration = Duration::from_secs(20);
+/// Refuse to buffer more than this from the API (the real body is ~10 KB).
+#[cfg(windows)]
+const MAX_BODY_BYTES: usize = 1 << 20;
+
+/// What the API told us about the newest release.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReleaseInfo {
+    /// Git tag, e.g. `v0.1.4`.
+    pub tag: String,
+    /// The tag parsed as a version.
+    pub version: semver::Version,
+    /// Release page for humans (notes, checksums, all assets).
+    pub url: String,
+    /// Direct link to [`INSTALLER_ASSET`] if the release has one.
+    pub installer_url: Option<String>,
+}
+
+/// `v0.1.4` / `V0.1.4` / `0.1.4` → `0.1.4`. Rejects anything that isn't a
+/// version once the `v` is gone (e.g. `driver-v1.1.0.204`).
+pub fn parse_tag_version(tag: &str) -> Result<semver::Version> {
+    let stripped = tag.trim().trim_start_matches(['v', 'V']);
+    semver::Version::parse(stripped).with_context(|| format!("release tag {tag:?} is not a version"))
+}
+
+/// The version this exe *is*, for comparison — `None` for dev builds.
+pub fn current_version() -> Option<semver::Version> {
+    crate::release_version().and_then(|v| semver::Version::parse(v).ok())
+}
+
+/// Strict semver ordering, so `0.1.5-rc.1` is *not* newer than `0.1.5`.
+pub fn is_newer(latest: &semver::Version, current: &semver::Version) -> bool {
+    latest > current
+}
+
+/// The newer release the banner should offer, if any — pure so it can be
+/// tested: `latest_tag` is the cached newest tag, `skipped_tag` the one
+/// the user dismissed for good, `hidden_until` the "Later" snooze.
+pub fn banner_candidate(
+    current: &semver::Version,
+    latest_tag: &str,
+    skipped_tag: Option<&str>,
+    hidden_until: Option<u64>,
+    now_unix: u64,
+) -> Option<semver::Version> {
+    let latest = parse_tag_version(latest_tag).ok()?;
+    if !is_newer(&latest, current) {
+        return None;
+    }
+    if skipped_tag == Some(latest_tag) {
+        return None;
+    }
+    if matches!(hidden_until, Some(t) if now_unix < t) {
+        return None;
+    }
+    Some(latest)
+}
+
+/// Parse the `releases/latest` JSON body.
+pub fn parse_latest_release(json: &str) -> Result<ReleaseInfo> {
+    let v: serde_json::Value = serde_json::from_str(json).context("release JSON")?;
+    if v["draft"].as_bool() == Some(true) || v["prerelease"].as_bool() == Some(true) {
+        bail!("latest release is a draft or prerelease");
+    }
+    let tag = v["tag_name"].as_str().context("release JSON has no tag_name")?;
+    let version = parse_tag_version(tag)?;
+    let url = v["html_url"]
+        .as_str()
+        .filter(|u| u.starts_with("https://github.com/"))
+        .unwrap_or(RELEASES_PAGE)
+        .to_string();
+    let installer_url = v["assets"].as_array().and_then(|assets| {
+        assets
+            .iter()
+            .find(|a| a["name"].as_str() == Some(INSTALLER_ASSET))
+            .and_then(|a| a["browser_download_url"].as_str())
+            .map(str::to_string)
+    });
+    Ok(ReleaseInfo { tag: tag.to_string(), version, url, installer_url })
+}
+
+/// `stream-to-speaker/<version> (+repo url)` — GitHub requires a UA, and
+/// a descriptive one is the polite convention.
+pub fn user_agent() -> String {
+    format!("stream-to-speaker/{} (+https://github.com/{})", crate::display_version(), REPO)
+}
+
+/// One synchronous round-trip to GitHub. Blocks for up to the WinHTTP
+/// timeouts (~10-15 s); call it off the UI thread.
+pub fn fetch_latest_release() -> Result<ReleaseInfo> {
+    let (status, body) = http_get(API_HOST, API_PATH, &user_agent())?;
+    match status {
+        200 => parse_latest_release(&body),
+        404 => bail!("no release has been published yet"),
+        403 | 429 => bail!("GitHub rate limit reached{}", api_message(&body)),
+        s => bail!("GitHub API returned HTTP {s}{}", api_message(&body)),
+    }
+}
+
+/// GitHub error bodies carry a human `message`; surface it if present.
+fn api_message(body: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v["message"].as_str().map(|m| format!(": {m}")))
+        .unwrap_or_default()
+}
+
+/// HTTPS GET → (status, body). Windows-only by design (see module docs).
+#[cfg(windows)]
+fn http_get(host: &str, path: &str, user_agent: &str) -> Result<(u16, String)> {
+    use std::ffi::c_void;
+    use windows::core::PCWSTR;
+    use windows::Win32::Networking::WinHttp::*;
+
+    fn wide(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+    fn last_error(what: &str) -> anyhow::Error {
+        anyhow::anyhow!("{what}: {}", windows::core::Error::from_win32())
+    }
+    /// Closes the WinHTTP handle on drop, whichever way we leave.
+    struct Handle(*mut c_void);
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: a handle we opened, closed exactly once here.
+                unsafe {
+                    let _ = WinHttpCloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    // SAFETY: plain WinHTTP FFI. Every handle is owned by a `Handle` guard,
+    // every buffer outlives the call that reads it, and the wide strings
+    // are NUL-terminated by `wide`.
+    unsafe {
+        let ua = wide(user_agent);
+        let session = Handle(WinHttpOpen(
+            PCWSTR(ua.as_ptr()),
+            WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+            PCWSTR::null(),
+            PCWSTR::null(),
+            0,
+        ));
+        if session.0.is_null() {
+            return Err(last_error("WinHttpOpen"));
+        }
+        // resolve, connect, send, receive — milliseconds.
+        WinHttpSetTimeouts(session.0, 10_000, 10_000, 10_000, 15_000).context("WinHttpSetTimeouts")?;
+
+        let host_w = wide(host);
+        let conn = Handle(WinHttpConnect(session.0, PCWSTR(host_w.as_ptr()), 443, 0));
+        if conn.0.is_null() {
+            return Err(last_error("WinHttpConnect"));
+        }
+
+        let verb = wide("GET");
+        let object = wide(path);
+        let req = Handle(WinHttpOpenRequest(
+            conn.0,
+            PCWSTR(verb.as_ptr()),
+            PCWSTR(object.as_ptr()),
+            PCWSTR::null(),
+            PCWSTR::null(),
+            std::ptr::null(),
+            WINHTTP_FLAG_SECURE,
+        ));
+        if req.0.is_null() {
+            return Err(last_error("WinHttpOpenRequest"));
+        }
+
+        let headers = wide("Accept: application/vnd.github+json\r\nX-GitHub-Api-Version: 2022-11-28\r\n");
+        // Length excludes the terminator (the binding passes the slice length).
+        WinHttpAddRequestHeaders(req.0, &headers[..headers.len() - 1], WINHTTP_ADDREQ_FLAG_ADD)
+            .context("WinHttpAddRequestHeaders")?;
+        WinHttpSendRequest(req.0, None, None, 0, 0, 0).context("WinHttpSendRequest")?;
+        WinHttpReceiveResponse(req.0, std::ptr::null_mut()).context("WinHttpReceiveResponse")?;
+
+        let mut status: u32 = 0;
+        let mut len: u32 = std::mem::size_of::<u32>() as u32;
+        WinHttpQueryHeaders(
+            req.0,
+            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+            PCWSTR::null(),
+            Some(&mut status as *mut u32 as *mut c_void),
+            &mut len,
+            std::ptr::null_mut(),
+        )
+        .context("WinHttpQueryHeaders(status)")?;
+
+        let mut body: Vec<u8> = Vec::new();
+        loop {
+            let mut avail: u32 = 0;
+            WinHttpQueryDataAvailable(req.0, &mut avail).context("WinHttpQueryDataAvailable")?;
+            if avail == 0 {
+                break;
+            }
+            if body.len() + avail as usize > MAX_BODY_BYTES {
+                bail!("response larger than {} bytes", MAX_BODY_BYTES);
+            }
+            let mut chunk = vec![0u8; avail as usize];
+            let mut read: u32 = 0;
+            WinHttpReadData(req.0, chunk.as_mut_ptr() as *mut c_void, avail, &mut read)
+                .context("WinHttpReadData")?;
+            if read == 0 {
+                break;
+            }
+            chunk.truncate(read as usize);
+            body.extend_from_slice(&chunk);
+        }
+        Ok((status as u16, String::from_utf8_lossy(&body).into_owned()))
+    }
+}
+
+#[cfg(not(windows))]
+fn http_get(_host: &str, _path: &str, _user_agent: &str) -> Result<(u16, String)> {
+    bail!("update checks are only implemented on Windows (WinHTTP)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> semver::Version {
+        semver::Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn tag_parsing_strips_v_and_rejects_non_versions() {
+        assert_eq!(parse_tag_version("v0.1.4").unwrap(), v("0.1.4"));
+        assert_eq!(parse_tag_version("V1.2.3").unwrap(), v("1.2.3"));
+        assert_eq!(parse_tag_version("1.2.3-rc.1").unwrap(), v("1.2.3-rc.1"));
+        // The driver prerelease tags must never be mistaken for the app.
+        assert!(parse_tag_version("driver-v1.1.0.204").is_err());
+        assert!(parse_tag_version("").is_err());
+    }
+
+    #[test]
+    fn newer_is_strict_semver() {
+        assert!(is_newer(&v("0.1.5"), &v("0.1.4")));
+        assert!(is_newer(&v("1.0.0"), &v("0.9.9")));
+        assert!(!is_newer(&v("0.1.4"), &v("0.1.4")));
+        assert!(!is_newer(&v("0.1.3"), &v("0.1.4")));
+        // A prerelease of the next version is not "newer" than it.
+        assert!(!is_newer(&v("0.1.5-rc.1"), &v("0.1.5")));
+        assert!(is_newer(&v("0.1.5-rc.1"), &v("0.1.4")));
+    }
+
+    #[test]
+    fn parses_the_real_api_shape() {
+        // Trimmed from a live `releases/latest` response.
+        let json = r#"{
+          "html_url": "https://github.com/Mihonarium/StreamToSpeaker/releases/tag/v0.1.4",
+          "tag_name": "v0.1.4", "name": "v0.1.4", "draft": false, "prerelease": false,
+          "assets": [
+            {"name": "stream-to-speaker-0.1.4.exe", "browser_download_url": "https://x/a"},
+            {"name": "StreamToSpeakerSetup.exe",
+             "browser_download_url": "https://github.com/Mihonarium/StreamToSpeaker/releases/download/v0.1.4/StreamToSpeakerSetup.exe"}
+          ]
+        }"#;
+        let r = parse_latest_release(json).unwrap();
+        assert_eq!(r.tag, "v0.1.4");
+        assert_eq!(r.version, v("0.1.4"));
+        assert_eq!(r.url, "https://github.com/Mihonarium/StreamToSpeaker/releases/tag/v0.1.4");
+        assert_eq!(
+            r.installer_url.as_deref(),
+            Some("https://github.com/Mihonarium/StreamToSpeaker/releases/download/v0.1.4/StreamToSpeakerSetup.exe")
+        );
+    }
+
+    #[test]
+    fn rejects_prerelease_draft_and_garbage() {
+        assert!(parse_latest_release(r#"{"tag_name":"v9.9.9","prerelease":true}"#).is_err());
+        assert!(parse_latest_release(r#"{"tag_name":"v9.9.9","draft":true}"#).is_err());
+        assert!(parse_latest_release(r#"{"message":"Not Found"}"#).is_err());
+        assert!(parse_latest_release("not json").is_err());
+        // No assets / no html_url still yields a usable release.
+        let r = parse_latest_release(r#"{"tag_name":"v0.2.0"}"#).unwrap();
+        assert_eq!(r.url, RELEASES_PAGE);
+        assert_eq!(r.installer_url, None);
+    }
+
+    #[test]
+    fn banner_respects_skip_and_snooze() {
+        let cur = v("0.1.4");
+        assert_eq!(banner_candidate(&cur, "v0.1.5", None, None, 1000), Some(v("0.1.5")));
+        // Not newer → nothing.
+        assert_eq!(banner_candidate(&cur, "v0.1.4", None, None, 1000), None);
+        assert_eq!(banner_candidate(&cur, "v0.1.3", None, None, 1000), None);
+        // Skipped exactly this tag → nothing; a later one shows again.
+        assert_eq!(banner_candidate(&cur, "v0.1.5", Some("v0.1.5"), None, 1000), None);
+        assert_eq!(banner_candidate(&cur, "v0.1.6", Some("v0.1.5"), None, 1000), Some(v("0.1.6")));
+        // Snoozed until 2000: hidden at 1500, back at 2000.
+        assert_eq!(banner_candidate(&cur, "v0.1.5", None, Some(2000), 1500), None);
+        assert_eq!(banner_candidate(&cur, "v0.1.5", None, Some(2000), 2000), Some(v("0.1.5")));
+        // Garbage cached tag → nothing, never a panic.
+        assert_eq!(banner_candidate(&cur, "driver-v1.1.0.204", None, None, 1000), None);
+    }
+
+    #[test]
+    fn dev_builds_have_no_current_version() {
+        if crate::release_version().is_none() {
+            assert!(current_version().is_none());
+        }
+    }
+
+    #[test]
+    fn api_message_is_optional() {
+        assert_eq!(api_message(r#"{"message":"API rate limit exceeded"}"#), ": API rate limit exceeded");
+        assert_eq!(api_message("<html>"), "");
+    }
+
+    /// Live round-trip through WinHTTP to GitHub. Ignored by default (needs
+    /// Windows + network): `cargo test -- --ignored live_github_fetch`.
+    #[test]
+    #[ignore]
+    fn live_github_fetch() {
+        let r = fetch_latest_release().expect("fetch latest release");
+        assert!(r.tag.starts_with('v'));
+        assert!(r.url.starts_with("https://github.com/"));
+    }
+}

--- a/service/src/user_config.rs
+++ b/service/src/user_config.rs
@@ -133,6 +133,29 @@ pub struct UserConfig {
     /// to [`AIRPLAY_LATENCY_MS_MIN`]..=[`AIRPLAY_LATENCY_MS_MAX`] on read.
     #[serde(default = "default_airplay_latency_ms")]
     pub airplay_latency_ms: u32,
+    /// Once-a-day check for a newer release on GitHub (Advanced toggle).
+    /// One unauthenticated GET of the releases API; nothing is downloaded
+    /// or installed. On by default. See `update_check`.
+    #[serde(default = "default_true")]
+    pub check_for_updates: bool,
+    /// Unix seconds of the last completed update check, any outcome —
+    /// paces the automatic check across launches.
+    #[serde(default)]
+    pub update_last_check_unix: Option<u64>,
+    /// Newest release seen by the last successful check: tag + release
+    /// page. Cached so the banner is right from the first frame after
+    /// launch (the check itself runs 20 s in) and on an offline launch.
+    #[serde(default)]
+    pub update_latest_tag: Option<String>,
+    #[serde(default)]
+    pub update_latest_url: Option<String>,
+    /// Tag the user chose "Skip this version" on — the banner stays
+    /// hidden until a *different* newer release appears.
+    #[serde(default)]
+    pub update_skipped_tag: Option<String>,
+    /// "Later" on the update banner: hidden until this unix time.
+    #[serde(default)]
+    pub update_banner_hidden_until: Option<u64>,
 }
 
 /// Default AirPlay buffer — iTunes' 2 s (88200 samples at 44.1 kHz).
@@ -143,6 +166,10 @@ pub const AIRPLAY_LATENCY_MS_DEFAULT: u32 = 2000;
 pub const AIRPLAY_LATENCY_MS_MIN: u32 = 20;
 /// Ceiling for `airplay_latency_ms` (3 s — "buffered" territory).
 pub const AIRPLAY_LATENCY_MS_MAX: u32 = 3000;
+
+fn default_true() -> bool {
+    true
+}
 
 fn default_airplay_latency_ms() -> u32 {
     AIRPLAY_LATENCY_MS_DEFAULT
@@ -231,6 +258,8 @@ mod tests {
         assert_eq!(c.airplay_latency_ms, AIRPLAY_LATENCY_MS_DEFAULT);
         assert!(c.auto_reconnect_on_launch);
         assert!(c.auto_reconnect_on_drop);
+        assert!(c.check_for_updates);
+        assert_eq!(c.update_last_check_unix, None);
         assert!(!c.prefer_realtime_airplay);
     }
 


### PR DESCRIPTION
Stacked on the AirPlay latency PR (needs its `UserConfig::default` fix, otherwise a fresh install would persist the new on-by-default switch as off).

Once a day the app asks `api.github.com/repos/…/releases/latest` (~20 s after launch, then at most every 24 h, persisted), compares the release tag with this build's tag by strict semver, and shows a banner with **Download** (opens the release page) / **Skip this version** / **Later**. Nothing is downloaded or installed automatically. The Help menu gets a status line and "Check for updates now"; Advanced gets the on/off switch (on by default — a plain GET carrying only the app version).

## Design choices

- **Transport: WinHTTP** — the OS HTTPS stack, so the system cert store and proxy apply and no TLS crate is bundled. The fetch is Windows-only by design; everything else is unit-tested cross-platform.
- **`releases/latest`** excludes drafts and prereleases server-side, so the `driver-v*` entries never match; the parser rejects them again defensively.
- No ETag / conditional requests: one request a day is nothing against the 60/h unauthenticated limit, and the extra state isn't worth it.

## The version-mismatch bug this exposed

The crate version (0.6.0) and the release tag (v0.1.4) are **independent**, so comparing `CARGO_PKG_VERSION` would have reported "up to date" forever. CI now bakes the tag into the exe as `STS_RELEASE_VERSION` on `v*` tag builds (`build.rs` declares `rerun-if-env-changed`); the update check compares that, and the header/About version label shows it too. Dev builds (no baked tag) show the crate version and never check.

## Verified

- Both `cargo check` targets clean; 100 tests pass, 7 new (tag parsing, semver ordering, real API JSON shape, prerelease/draft rejection, skip/snooze logic).
- Workflow YAML parses; the build step's `env` is `STS_RELEASE_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && steps.ver.outputs.version || '' }}`.

## Not verified

The WinHTTP round-trip itself can't run from Linux. On Windows: `cd service && cargo test -- --ignored live_github_fetch`. Also worth confirming on the first tag build after merge that the header reads the tag, not v0.6.0.
