### PR TITLE
GUI: notices can no longer paint buttons over their text

### DIFF
--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -1234,8 +1234,11 @@ impl eframe::App for StreamToSpeakerApp {
                             self.show_status_banner(ui, &p);
                             banner_bottom_px = ui.cursor().top();
                             self.show_error_banner(ui, &p);
-                            self.show_update_banner(ui, &p);
-                            self.show_donation_banner(ui, &p);
+                            // One ask at a time: an available update
+                            // outranks the donation strip.
+                            if !self.show_update_banner(ui, &p) {
+                                self.show_donation_banner(ui, &p);
+                            }
                             ui.add_space(sp::M);
                             // Show onboarding regardless of whether a
                             // speaker is currently bound, until the
@@ -1388,6 +1391,44 @@ fn window_close_cursor(ctx: &egui::Context, window_rect: egui::Rect, inner_margi
 
 /// Primary button — solid accent fill, white-on-accent text. Use for the
 /// main action of each area (Enable, Minimise to tray, Apply, etc.).
+/// A notice strip's content row: a message with right-aligned actions,
+/// laid out so the message can never run under the buttons. The buttons
+/// are placed first (right-to-left), then the message wraps in whatever
+/// width is left; if that would be too narrow to read, the row stacks —
+/// message on top, buttons right-aligned beneath. `buttons_w` is the
+/// buttons' total width including gaps (the caller knows it from the min
+/// widths it passes to the button helpers).
+///
+/// Why: a label added *before* a right-to-left button group claims the
+/// row at its full single-line width — labels don't wrap inside
+/// horizontal layouts — so past a certain window width the buttons were
+/// painted straight over the text. A fixed "stack below N px" threshold
+/// only moved that collision to a different window width (the donation
+/// strip overlapped at the default 720 px window).
+fn notice_row(
+    ui: &mut egui::Ui,
+    msg: egui::RichText,
+    buttons_w: f32,
+    buttons: impl FnOnce(&mut egui::Ui),
+) {
+    const MIN_TEXT_W: f32 = 240.0;
+    if ui.available_width() - buttons_w - sp::S < MIN_TEXT_W {
+        ui.vertical(|ui| {
+            ui.add(egui::Label::new(msg).wrap());
+            ui.add_space(sp::S);
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), buttons);
+        });
+    } else {
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            buttons(ui);
+            ui.add_space(sp::S);
+            ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                ui.add(egui::Label::new(msg).wrap());
+            });
+        });
+    }
+}
+
 fn primary_button(ui: &mut egui::Ui, p: &Palette, label: &str, min_width: f32) -> egui::Response {
     let btn = egui::Button::new(
         egui::RichText::new(label)
@@ -1510,6 +1551,9 @@ impl StreamToSpeakerApp {
             egui::PopupCloseBehavior::CloseOnClickOutside,
             |ui| {
                 ui.set_min_width(240.0);
+                // Bounded so a long status line wraps instead of
+                // widening the popup off-screen.
+                ui.set_max_width(360.0);
                 ui.label(
                     egui::RichText::new(format!(
                         "Stream To Speaker v{}",
@@ -1659,9 +1703,10 @@ impl StreamToSpeakerApp {
                 (
                     "3",
                     "Adjust the latency if audio drifts",
-                    "If audio lags the picture, use the Trim buttons. If it \
-                     glitches, use the Pad buttons. Resync gives an instant \
-                     fix at the cost of a brief audio click.",
+                    "If audio lags the picture, use −25 / −100 ms in the \
+                     Latency card. If it glitches or drops out, use \
+                     +25 / +100 ms. Resync speaker restarts the connection — \
+                     an instant fix at the cost of a brief click.",
                 ),
             ];
 
@@ -1786,25 +1831,14 @@ impl StreamToSpeakerApp {
                     ui.label(egui::RichText::new(icon).color(accent).size(34.0).strong());
                     ui.add_space(sp::S);
 
-                    ui.vertical(|ui| {
-                        ui.add_space(2.0);
-                        ui.label(
-                            egui::RichText::new(headline)
-                                .size(16.0)
-                                .strong()
-                                .color(p.text_primary),
-                        );
-                        ui.label(
-                            egui::RichText::new(detail)
-                                .size(12.0)
-                                .color(p.text_secondary),
-                        );
-                    });
-
-                    if let (Some(label), Some(tip)) = (btn_label, btn_tip) {
-                        ui.with_layout(
-                            egui::Layout::right_to_left(egui::Align::Center),
-                            |ui| {
+                    // Buttons first (right-aligned), the text column in
+                    // whatever is left, wrapping — so a long speaker name
+                    // folds onto a second line instead of running under
+                    // the buttons (the notice_row rule).
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            if let (Some(label), Some(tip)) = (btn_label, btn_tip) {
                                 ui.vertical(|ui| {
                                     ui.with_layout(
                                         egui::Layout::right_to_left(egui::Align::Center),
@@ -1865,9 +1899,31 @@ impl StreamToSpeakerApp {
                                         );
                                     }
                                 });
-                            },
-                        );
-                    }
+                                ui.add_space(sp::S);
+                            }
+
+                            ui.with_layout(egui::Layout::top_down(egui::Align::Min), |ui| {
+                                ui.add_space(2.0);
+                                ui.add(
+                                    egui::Label::new(
+                                        egui::RichText::new(headline)
+                                            .size(16.0)
+                                            .strong()
+                                            .color(p.text_primary),
+                                    )
+                                    .wrap(),
+                                );
+                                ui.add(
+                                    egui::Label::new(
+                                        egui::RichText::new(detail)
+                                            .size(12.0)
+                                            .color(p.text_secondary),
+                                    )
+                                    .wrap(),
+                                );
+                            });
+                        },
+                    );
                 });
             });
 
@@ -1925,23 +1981,10 @@ impl StreamToSpeakerApp {
                     ui.painter().circle_filled(rect.center(), 5.0, accent);
                     ui.add_space(sp::S);
 
-                    ui.label(
-                        egui::RichText::new(&current.friendly_name)
-                            .size(12.0)
-                            .strong()
-                            .color(p.text_primary),
-                    );
-                    ui.label(
-                        egui::RichText::new("·")
-                            .size(12.0)
-                            .color(p.text_tertiary),
-                    );
-                    ui.label(
-                        egui::RichText::new(status_text)
-                            .size(12.0)
-                            .color(p.text_secondary),
-                    );
-
+                    // Button first, then the text in what is left, with the
+                    // speaker name truncated (an ellipsis, not a wrap — this
+                    // bar is one line by design) so a long name can't run
+                    // under the button.
                     ui.with_layout(
                         egui::Layout::right_to_left(egui::Align::Center),
                         |ui| {
@@ -1968,6 +2011,36 @@ impl StreamToSpeakerApp {
                                     ));
                                 }
                             }
+                            ui.add_space(sp::S);
+                            ui.with_layout(
+                                egui::Layout::left_to_right(egui::Align::Center),
+                                |ui| {
+                                    // Leave room for " · Streaming" after the name.
+                                    let name_w = (ui.available_width() - 96.0).max(60.0);
+                                    ui.scope(|ui| {
+                                        ui.set_max_width(name_w);
+                                        ui.add(
+                                            egui::Label::new(
+                                                egui::RichText::new(&current.friendly_name)
+                                                    .size(12.0)
+                                                    .strong()
+                                                    .color(p.text_primary),
+                                            )
+                                            .truncate(),
+                                        );
+                                    });
+                                    ui.label(
+                                        egui::RichText::new("·")
+                                            .size(12.0)
+                                            .color(p.text_tertiary),
+                                    );
+                                    ui.label(
+                                        egui::RichText::new(status_text)
+                                            .size(12.0)
+                                            .color(p.text_secondary),
+                                    );
+                                },
+                            );
                         },
                     );
                 });
@@ -1997,29 +2070,21 @@ impl StreamToSpeakerApp {
                             .strong(),
                     );
                     ui.add_space(sp::XS);
-                    // Lay Dismiss out FIRST, then the message into what is
-                    // left. Adding the message first let it claim the whole
-                    // row, so the button — which has a transparent fill —
-                    // was drawn on top of the words. A long error message
-                    // now wraps instead of colliding.
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
+                    // Dismiss is laid out first and the message wraps into
+                    // what is left (notice_row), so a long error can't run
+                    // under the button.
+                    let mut dismiss = false;
+                    notice_row(
+                        ui,
+                        egui::RichText::new(&msg).color(p.text_primary),
+                        80.0,
                         |ui| {
-                            if link_button(ui, p, "Dismiss", 80.0).clicked() {
-                                self.app.dismiss_error();
-                            }
-                            ui.add_space(sp::S);
-                            ui.with_layout(
-                                egui::Layout::left_to_right(egui::Align::Center),
-                                |ui| {
-                                    ui.label(
-                                        egui::RichText::new(&msg)
-                                            .color(p.text_primary),
-                                    );
-                                },
-                            );
+                            dismiss = link_button(ui, p, "Dismiss", 80.0).clicked();
                         },
                     );
+                    if dismiss {
+                        self.app.dismiss_error();
+                    }
                 });
             });
     }
@@ -2074,18 +2139,14 @@ impl StreamToSpeakerApp {
         }
     }
 
-    /// Donation ask. Shown on launch until the user either follows the
-    /// link or asks to be reminded later; both choices persist, so it is
-    /// never the same nag twice in one week. Deliberately a quiet strip
-    /// rather than a modal — it must never stand between the user and
-    /// the speaker list.
-    /// "A newer version is available" strip. Same shape as the donation
-    /// banner; driven by the cached update-check result so it's present
-    /// from the first frame after launch. Never installs anything — the
-    /// primary action opens the release page in the browser.
-    fn show_update_banner(&mut self, ui: &mut egui::Ui, p: &Palette) {
+    /// "A newer version is available" strip. Driven by the cached
+    /// update-check result so it's present from the first frame after
+    /// launch. Never installs anything — the primary action opens the
+    /// release page in the browser. Returns whether it was shown, so the
+    /// caller can hold the donation strip back: one ask at a time.
+    fn show_update_banner(&mut self, ui: &mut egui::Ui, p: &Palette) -> bool {
         let Some(rel) = self.app.update_banner() else {
-            return;
+            return false;
         };
         ui.add_space(sp::XS);
         egui::Frame::none()
@@ -2093,59 +2154,30 @@ impl StreamToSpeakerApp {
             .rounding(RADIUS_SURFACE)
             .inner_margin(egui::Margin::symmetric(sp::M, sp::S))
             .show(ui, |ui| {
-                // Three buttons need ~330 px; stack below that so the
-                // message wraps on its own line instead of sliding under
-                // them (see show_donation_banner).
-                let stacked = ui.available_width() < 640.0;
                 let msg = egui::RichText::new(format!(
                     "⬆  Stream To Speaker {} is available — you have v{}.",
                     rel.tag,
                     crate::display_version()
                 ))
                 .color(p.text_on_accent_subtle);
-
-                let buttons = |ui: &mut egui::Ui| -> (bool, bool, bool) {
-                    let (mut download, mut skip, mut later) = (false, false, false);
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            later = secondary_button(ui, p, "Later", 72.0)
-                                .on_hover_text("Hide this for three days.")
-                                .clicked();
-                            skip = secondary_button(ui, p, "Skip this version", 130.0)
-                                .on_hover_text(
-                                    "Don't mention this version again. A later one will still show.",
-                                )
-                                .clicked();
-                            download = primary_button(ui, p, "Download", 100.0)
-                                .on_hover_text(
-                                    "Opens the release page on GitHub in your browser. \
-                                     Run the installer from there — nothing is installed \
-                                     automatically.",
-                                )
-                                .clicked();
-                        },
-                    );
-                    (download, skip, later)
-                };
-
-                let (download, skip, later) = if stacked {
-                    let mut clicks = (false, false, false);
-                    ui.vertical(|ui| {
-                        ui.label(msg);
-                        ui.add_space(sp::S);
-                        clicks = buttons(ui);
-                    });
-                    clicks
-                } else {
-                    let mut clicks = (false, false, false);
-                    ui.horizontal(|ui| {
-                        ui.label(msg);
-                        clicks = buttons(ui);
-                    });
-                    clicks
-                };
-
+                let (mut download, mut skip, mut later) = (false, false, false);
+                notice_row(ui, msg, 100.0 + 130.0 + 72.0 + 2.0 * sp::XS, |ui| {
+                    later = secondary_button(ui, p, "Later", 72.0)
+                        .on_hover_text("Hide this for three days.")
+                        .clicked();
+                    skip = secondary_button(ui, p, "Skip this version", 130.0)
+                        .on_hover_text(
+                            "Don't mention this version again. A later one will still show.",
+                        )
+                        .clicked();
+                    download = primary_button(ui, p, "Download", 100.0)
+                        .on_hover_text(
+                            "Opens the release page on GitHub in your browser. \
+                             Run the installer from there — nothing is installed \
+                             automatically.",
+                        )
+                        .clicked();
+                });
                 if download {
                     let _ = open_url(&rel.url);
                 }
@@ -2156,6 +2188,7 @@ impl StreamToSpeakerApp {
                     self.app.snooze_update_banner(3);
                 }
             });
+        true
     }
 
     /// One-line update status for the Help menu, plus whether the
@@ -2179,11 +2212,20 @@ impl StreamToSpeakerApp {
             Some((UpdateOutcome::DevBuild, _)) => {
                 "Development build — update checks are off.".to_string()
             }
-            Some((UpdateOutcome::Failed(e), _)) => format!("Couldn't check for updates: {e}"),
+            Some((UpdateOutcome::Failed(e), _)) => {
+                // One line of reason is plenty in a popup; the log has it all.
+                let e: String = e.chars().take(90).collect();
+                format!("Couldn't check for updates: {e}")
+            }
         };
         (line, false)
     }
 
+    /// Donation ask. Shown on launch until the user either follows the
+    /// link or asks to be reminded later; both choices persist, so it is
+    /// never the same nag twice in one week. Deliberately a quiet strip
+    /// rather than a modal — it must never stand between the user and
+    /// the speaker list.
     fn show_donation_banner(&mut self, ui: &mut egui::Ui, p: &Palette) {
         if !self.app.should_show_donation_prompt() {
             return;
@@ -2194,55 +2236,23 @@ impl StreamToSpeakerApp {
             .rounding(RADIUS_SURFACE)
             .inner_margin(egui::Margin::symmetric(sp::M, sp::S))
             .show(ui, |ui| {
-                // Buttons need ~200 px. On a narrow window the message used
-                // to share their row and slide underneath them (labels don't
-                // wrap inside a horizontal layout), so below the threshold
-                // the strip stacks: message on its own line — where it wraps
-                // — and the buttons right-aligned beneath it.
-                let stacked = ui.available_width() < 540.0;
                 let msg = egui::RichText::new(
                     "☕  Stream To Speaker is free and open source. \
                      Donate to support its development.",
                 )
                 .color(p.text_on_accent_subtle);
-
-                let buttons = |ui: &mut egui::Ui| -> (bool, bool) {
-                    let mut donate = false;
-                    let mut later = false;
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            later = secondary_button(ui, p, "Not now", 84.0)
-                                .on_hover_text("Hide this for a week.")
-                                .clicked();
-                            donate = primary_button(ui, p, "Donate", 96.0)
-                                .on_hover_text(
-                                    "Opens buymeacoffee.com/ms00 in your browser. \
-                                     Any amount, one-off or monthly.",
-                                )
-                                .clicked();
-                        },
-                    );
-                    (donate, later)
-                };
-
-                let (donate, later) = if stacked {
-                    let mut clicks = (false, false);
-                    ui.vertical(|ui| {
-                        ui.label(msg);
-                        ui.add_space(sp::S);
-                        clicks = buttons(ui);
-                    });
-                    clicks
-                } else {
-                    let mut clicks = (false, false);
-                    ui.horizontal(|ui| {
-                        ui.label(msg);
-                        clicks = buttons(ui);
-                    });
-                    clicks
-                };
-
+                let (mut donate, mut later) = (false, false);
+                notice_row(ui, msg, 96.0 + 84.0 + sp::XS, |ui| {
+                    later = secondary_button(ui, p, "Not now", 84.0)
+                        .on_hover_text("Hide this for a week.")
+                        .clicked();
+                    donate = primary_button(ui, p, "Donate", 96.0)
+                        .on_hover_text(
+                            "Opens buymeacoffee.com/ms00 in your browser. \
+                             Any amount, one-off or monthly.",
+                        )
+                        .clicked();
+                });
                 if later {
                     self.app.snooze_donation_prompt(7);
                 }


### PR DESCRIPTION
Stacked on the update-check PR (the update strip shares the fixed code).

## The overlap

The donation strip added its message *before* the right-aligned button group. Labels don't wrap inside egui horizontal layouts, so the message claimed the row at its full single-line width and the buttons were painted over its tail — at the **default 720 px window**, since the "stack below 540 px" guard sat well under the ~800 px the row needs. The new update strip had inherited the same shape.

## Fixes

- **`notice_row()`**: shared row for the donation, update and error strips. Buttons laid out first (right-to-left), the message wraps in what is left; under 240 px it stacks instead. No width thresholds to get wrong.
- **Status banner**: same rule — button column first, headline/detail wrap, so a long speaker name folds instead of running under Enable/Disable.
- **Pinned status bar**: button first, speaker name truncated with an ellipsis (one line by design), room reserved for " · Streaming".
- **One ask at a time**: the donation strip stays hidden while the update strip shows.
- **Help popup** gets a max width so a long status line wraps rather than widening it off-screen.
- **Onboarding step 3** referred to "Trim" and "Pad" buttons that don't exist; it now names the actual −25 / −100 ms, +25 / +100 ms and Resync speaker controls.

## Verified / not

`cargo check --target x86_64-pc-windows-gnu` (the target that compiles the GUI) clean; Linux check and 100 tests unchanged. The GUI can't be rendered from Linux, so please eyeball: the default window with the donation strip visible; a speaker with a long name in both the big banner and the pinned bar; the window at its 580 px minimum with an error showing.
