### PR TITLE
GUI: fix notice strips filling the page and the status headline going vertical

### DIFF
--- a/service/src/gui.rs
+++ b/service/src/gui.rs
@@ -1405,6 +1405,14 @@ fn window_close_cursor(ctx: &egui::Context, window_rect: egui::Rect, inner_margi
 /// painted straight over the text. A fixed "stack below N px" threshold
 /// only moved that collision to a different window width (the donation
 /// strip overlapped at the default 720 px window).
+///
+/// Every right-to-left row here is wrapped in `ui.horizontal`, which
+/// bounds the row's height. A vertically-centred horizontal layout dropped
+/// straight into an unbounded ui (the scroll area's content) centres its
+/// widgets within an infinite height — i.e. at y = ∞ — and the enclosing
+/// frame then paints the whole page. `main`'s stacked branch did this at
+/// the 580 px minimum width; the first cut of this helper did it at every
+/// width. Verified with a headless egui layout harness.
 fn notice_row(
     ui: &mut egui::Ui,
     msg: egui::RichText,
@@ -1416,14 +1424,18 @@ fn notice_row(
         ui.vertical(|ui| {
             ui.add(egui::Label::new(msg).wrap());
             ui.add_space(sp::S);
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), buttons);
+            ui.horizontal(|ui| {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), buttons);
+            });
         });
     } else {
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            buttons(ui);
-            ui.add_space(sp::S);
-            ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
-                ui.add(egui::Label::new(msg).wrap());
+        ui.horizontal(|ui| {
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                buttons(ui);
+                ui.add_space(sp::S);
+                ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                    ui.add(egui::Label::new(msg).wrap());
+                });
             });
         });
     }
@@ -1839,7 +1851,17 @@ impl StreamToSpeakerApp {
                         egui::Layout::right_to_left(egui::Align::Center),
                         |ui| {
                             if let (Some(label), Some(tip)) = (btn_label, btn_tip) {
-                                ui.vertical(|ui| {
+                                // Explicit-width, right-aligned column. A plain
+                                // `ui.vertical` here claims the full remaining
+                                // width — its bounding box reaches the left edge
+                                // — so the text column laid out after it got
+                                // ~0 px and the headline came out one word per
+                                // line. Verified with the headless harness.
+                                let col_h = ui.available_height();
+                                ui.allocate_ui_with_layout(
+                                    egui::vec2(140.0, col_h),
+                                    egui::Layout::top_down(egui::Align::Max),
+                                    |ui| {
                                     ui.with_layout(
                                         egui::Layout::right_to_left(egui::Align::Center),
                                         |ui| {
@@ -1898,7 +1920,8 @@ impl StreamToSpeakerApp {
                                             },
                                         );
                                     }
-                                });
+                                    },
+                                );
                                 ui.add_space(sp::S);
                             }
 


### PR DESCRIPTION
Two regressions from #58, reported after merge: the donation strip filled the whole page, and the "Streaming to …" headline came out one word per line.

Both are reproduced and the fixes verified with a **headless egui layout harness** (the app's layouts rebuilt in a scratch crate on egui 0.29.1, one CPU frame at 580/720/900 px, frame/button/text rects inspected). No Windows machine was involved — which is also why #58 shipped them: the cross-compile can't catch layout.

## What was wrong

- **`notice_row`** placed a vertically-centred right-to-left layout straight into the scroll area's unbounded content ui. egui centres widgets within an infinite height — at y = ∞ — so the enclosing frame painted the whole page (743 px tall at every width). Every such row now lives inside `ui.horizontal`, which bounds the row height. `main`'s original stacked branch had the same fault at the 580 px minimum width.
- **Status banner** button column was a plain `ui.vertical`, whose bounding box reaches the left edge; laid out before the text column, it left ~0 px for the headline (14 px × 39 lines). It's now an explicit-width, right-aligned `allocate_ui_with_layout`.

## Harness results

| layout | 580 px | 720 px | 900 px |
|---|---|---|---|
| donation strip (#58 as merged) | 743 px frame | 743 px frame | 743 px frame |
| donation strip (this PR) | 56 px, 2 lines | 56 px, 2 lines | 56 px, 1 line |
| status banner (#58 as merged) | 39-line headline | 39-line headline | 39-line headline |
| status banner (this PR) | 102 px, 2 lines | 102 px, 1 line | 102 px, 1 line |
| update strip, 3 buttons (this PR) | stacks, 85 px | inline, 2 lines | inline, 1 line |

Banner height is back to exactly `main`'s 102 px. No text/button overlap in any case. The pinned bar truncates correctly.
